### PR TITLE
Update dependencies to newest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You will get `target/seadroid.apk` after the build finishes.
 
 ### Build
 
-- Download `ActionBarSherlock` 4.2.0 from http://actionbarsherlock.com/download.html
+- Download `ActionBarSherlock` 4.4.0 from http://actionbarsherlock.com/download.html
 - Download `ViewPagerIndicator` 2.4.1 from http://viewpagerindicator.com
 
 - Git clone `NewQuickAction`
@@ -32,10 +32,10 @@ You will get `target/seadroid.apk` after the build finishes.
 
 - Replace the android-support-v4.jar in `ActionBarSherlock` and `ViewPagerIndicator` with the jar in seadroid to make sure that all versions of this library be the same at this time.
 
-- Download these JARs to `seadroid/libs` directory:  
-    - [http-request-5.3.jar](http://mvnrepository.com/artifact/com.github.kevinsawicki/http-request/5.3)
+- Download these JARs to `seadroid/libs` directory (check pom.xml to verify versions):
+    - [http-request-5.6.jar](http://mvnrepository.com/artifact/com.github.kevinsawicki/http-request/5.6)
     - [commons-io-2.4.jar](http://repo1.maven.org/maven2/commons-io/commons-io/2.4/commons-io-2.4.jar)
-    - [guava-16.0.1.jar](http://search.maven.org/remotecontent?filepath=com/google/guava/guava/16.0.1/guava-16.0.1.jar)
+    - [guava-17.0.jar](http://search.maven.org/remotecontent?filepath=com/google/guava/guava/17.0/guava-17.0.jar)
 
 Now you can build seadroid in eclipse.
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <platform.version>4.1.1.4</platform.version>
-    <android.plugin.version>3.9.0-rc.1</android.plugin.version>
+    <android.plugin.version>3.9.0-rc.2</android.plugin.version>
   </properties>
 
   <dependencies>
@@ -32,8 +32,8 @@
     </dependency>
     <dependency>
       <groupId>com.actionbarsherlock</groupId>
-      <artifactId>library</artifactId>
-      <version>4.1.0</version>
+      <artifactId>actionbarsherlock</artifactId>
+      <version>4.4.0</version>
       <type>apklib</type>
       <exclusions>
         <exclusion>
@@ -49,9 +49,16 @@
       <type>apklib</type>
     </dependency>
     <dependency>
+	  <groupId>com.github.lorensiuswlt</groupId>
+	  <artifactId>NewQuickAction</artifactId>
+      <version>1.0</version>
+      <type>apklib</type>
+    </dependency>
+
+    <dependency>
       <groupId>com.github.kevinsawicki</groupId>
       <artifactId>http-request</artifactId>
-      <version>5.4.1</version>
+      <version>5.6</version>
     </dependency>
     <dependency>
 	  <groupId>commons-io</groupId>
@@ -61,7 +68,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>16.0.1</version>
+      <version>17.0</version>
     </dependency>
 
     <dependency>
@@ -74,13 +81,6 @@
 	  <groupId>com.github.falnatsheh</groupId>
 	  <artifactId>markdownview</artifactId>
       <version>1.2</version>
-    </dependency>
-
-    <dependency>
-	  <groupId>com.github.lorensiuswlt</groupId>
-	  <artifactId>NewQuickAction</artifactId>
-      <version>1.0</version>
-      <type>apklib</type>
     </dependency>
 
     <!-- test dependencies  -->

--- a/project.properties
+++ b/project.properties
@@ -12,6 +12,6 @@ proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.
 
 # Project target.
 target=android-17
-android.library.reference.1=../ActionBarSherlock-4.2.0/library
-android.library.reference.2=../NewQuickAction
-android.library.reference.3=../Android-ViewPagerIndicator/pagerlibrary
+android.library.reference.1=../NewQuickAction
+android.library.reference.2=../Android-ViewPagerIndicator/pagerlibrary
+android.library.reference.3=../ActionBarSherlock-4.4.0/actionbarsherlock


### PR DESCRIPTION
Also make the README.md versions in sync with the actual versions
being used in the pom.xml file.

This change has not been much tested, have just compiled and
done some initial tests.

The ActionBarSherlock version 4.4.0 is supposed to have gradle support, so it shold be easier to use when using Android Studio.
