### PR TITLE
AutoUpdateInfo: fix equals method to use String equals

### DIFF
--- a/src/com/seafile/seadroid2/monitor/AutoUpdateManager.java
+++ b/src/com/seafile/seadroid2/monitor/AutoUpdateManager.java
@@ -225,10 +225,13 @@ class AutoUpdateInfo {
             return false;
 
         AutoUpdateInfo that = (AutoUpdateInfo) obj;
+        if(that.account == null || that.repoID == null || that.repoName == null || that.parentDir == null || that.localPath == null) {
+            return false;
+        }
 
-        return this.account == that.account && this.repoID == that.repoID
-                && this.repoName == that.repoName && this.parentDir == that.parentDir
-                && this.localPath == that.localPath;
+        return that.account.equals(this.account) && that.repoID.equals(this.repoID) &&
+                that.repoName.equals(this.repoName) && that.parentDir.equals(this.parentDir) &&
+                that.localPath.equals(this.localPath);
     }
 
     private volatile int hashCode = 0;


### PR DESCRIPTION
This change has not been tested, but the implementation of
the equals method for AutoUpdateInfo seems wrong, also when
one look at the hashCode method.

So instead of using == for comparing strings, use the String.equals
method.

I am guessing that the current implementation of the equals may be
causing duplicate files to be uploaded, ref problems in pull request
number 43, but this is highly speculative from my side.

I've changed the implementation of the equals method to be like
the other overriden equals methods in the project.

If my changes are wrong, the equals method in AutoUpdateInfo should
receive some comments as to why the use of == is correct
