### PR TITLE
DataManager: return empty list when account has no repos

### DIFF
--- a/src/com/seafile/seadroid2/data/DataManager.java
+++ b/src/com/seafile/seadroid2/data/DataManager.java
@@ -299,7 +299,8 @@ public class DataManager {
             // may throw ClassCastException
             JSONArray array = Utils.parseJsonArray(json);
             if (array.length() == 0)
-                return null;
+                return new ArrayList<SeafRepo>(0);
+
             ArrayList<SeafRepo> repos = new ArrayList<SeafRepo>();
             for (int i = 0; i < array.length(); i++) {
                 JSONObject obj = array.getJSONObject(i);
@@ -359,8 +360,8 @@ public class DataManager {
             throw SeafException.networkException;
         }
 
-        // Log.d(DEBUG_TAG, "get repos from server");
         String json = sc.getRepos();
+        //Log.d(DEBUG_TAG, "get repos from server " + json);
         if (json == null)
             return null;
 


### PR DESCRIPTION
When an account has not repos, the user should get info about it
in the GUI.
Currently, the DataManager returns null in that case, and then the
GUI display message about error fetching repos.
So change the DataManager to return empty list of repos in this case,
and then the GUI displays message that there are no libraries yet.
