### PR TITLE
RepoView: add support for deleting a cache file

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="file_action_share">Share</string>
     <string name="file_action_export">Export</string>
     <string name="file_action_delete">Delete</string>
+    <string name="file_action_delete_cache_file">Delete cache</string>
     <string name="file_action_rename">Rename</string>
     <string name="file_action_open_as">Open as</string>
     <string-array name="file_type_array">

--- a/src/com/seafile/seadroid2/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/BrowserActivity.java
@@ -51,6 +51,7 @@ import com.actionbarsherlock.view.MenuItem;
 import com.actionbarsherlock.view.Window;
 import com.seafile.seadroid2.account.Account;
 import com.seafile.seadroid2.data.DataManager;
+import com.seafile.seadroid2.data.SeafCachedFile;
 import com.seafile.seadroid2.data.SeafDirent;
 import com.seafile.seadroid2.data.SeafRepo;
 import com.seafile.seadroid2.data.SeafStarredFile;
@@ -1091,7 +1092,6 @@ public class BrowserActivity extends SherlockFragmentActivity
 
     @Override
     public void onStarredFileSelected(SeafStarredFile starredFile) {
-
         final String repoID = starredFile.getRepoID();
         SeafRepo seafRepo = dataManager.getCachedRepoByID(repoID);
         final String repoName = seafRepo.getName();
@@ -1377,6 +1377,24 @@ public class BrowserActivity extends SherlockFragmentActivity
             }
         });
         dialog.show(getSupportFragmentManager(), "DialogFragment");
+    }
+
+    public void deleteCache(SeafDirent dirent) {
+        // We only support deleting a cache file as of now, later on
+        // we could support deleting all cached files in a directory
+        if(!dirent.isDir()) {
+            String fileName = dirent.name;
+            final String repoName = navContext.getRepoName();
+            final String repoID = navContext.getRepoID();
+            final String filePath = Utils.pathJoin(navContext.getDirPath(), fileName);
+
+            SeafCachedFile cachedFile = dataManager.getCachedFile(repoName, repoID, filePath);
+            if(cachedFile != null) {
+                Log.d(DEBUG_TAG, "Will delete cache file " + filePath + ", " + fileName);
+                dataManager.removeCachedFile(cachedFile);
+                tabsFragment.getReposFragment().refreshView(true);
+            }
+        }
     }
 
     private void onFileUploadProgress(int taskID) {

--- a/src/com/seafile/seadroid2/ui/SeafItemAdapter.java
+++ b/src/com/seafile/seadroid2/ui/SeafItemAdapter.java
@@ -31,7 +31,6 @@ import com.seafile.seadroid2.data.SeafItem;
 import com.seafile.seadroid2.data.SeafRepo;
 
 public class SeafItemAdapter extends BaseAdapter {
-
     private ArrayList<SeafItem> items;
     private BrowserActivity mActivity;
     private boolean repoIsEncrypted;
@@ -47,6 +46,7 @@ public class SeafItemAdapter extends BaseAdapter {
     private static final int ACTION_ID_RENAME = 3;
     private static final int ACTION_ID_DELETE = 4;
     private static final int ACTION_ID_SHARE = 5;
+    private static final int ACTION_ID_DELETE_CACHE = 6;
 
     @Override
     public int getCount() {
@@ -323,7 +323,7 @@ public class SeafItemAdapter extends BaseAdapter {
     private QuickAction prepareFileAction(final SeafDirent dirent, boolean cacheExists) {
         final QuickAction mQuickAction = new QuickAction(mActivity);
         Resources resources = mActivity.getResources();
-        ActionItem shareAction, downloadAction, updateAction, exportAction, renameAction, deleteAction;
+        ActionItem shareAction, downloadAction, updateAction, exportAction, renameAction, deleteAction, deleteCacheAction;
 
         if (!repoIsEncrypted) {
             shareAction = new ActionItem(ACTION_ID_SHARE,
@@ -354,7 +354,10 @@ public class SeafItemAdapter extends BaseAdapter {
                         resources.getDrawable(R.drawable.action_update));
                 mQuickAction.addActionItem(updateAction);
             }
-
+            deleteCacheAction = new ActionItem(ACTION_ID_DELETE_CACHE,
+                    resources.getString(R.string.file_action_delete_cache_file),
+                    resources.getDrawable(R.drawable.action_delete));
+            mQuickAction.addActionItem(deleteCacheAction);
         } else {
             downloadAction = new ActionItem(ACTION_ID_DOWNLOAD,
                     resources.getString(R.string.file_action_download),
@@ -388,6 +391,9 @@ public class SeafItemAdapter extends BaseAdapter {
                     break;
                 case ACTION_ID_RENAME:
                     mActivity.renameFile(repoID, repoName, path);
+                    break;
+                case ACTION_ID_DELETE_CACHE:
+                    mActivity.deleteCache(dirent);
                     break;
                 }
             }


### PR DESCRIPTION
The user should be able to quite easily delete a cached file, so
add menu option to delete the cache file if a file is cached on the
device by seafile.
