### PR TITLE
BrowserActivity: handle case where no path is returned for file to upload

### DIFF
--- a/src/com/seafile/seadroid2/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/BrowserActivity.java
@@ -1053,6 +1053,11 @@ public class BrowserActivity extends SherlockFragmentActivity
                     e.printStackTrace();
                     return;
                 }
+                if(path == null) {
+                    showToast("Unable to upload, no path available");
+                    Log.i(DEBUG_TAG, "Pick file request did not return a path");
+                    return;
+                }
                 showToast(getString(R.string.added_to_upload_tasks));
                 //showToast(getString(R.string.upload) + " " + Utils.fileNameFromPath(path));
                 addUploadTask(navContext.getRepoID(),


### PR DESCRIPTION
When the user chooses the "Other" upload method, and then selects an image,
the path will be null, and it will cause a nullpointer in BrowserActivity.
Rudimentary avoid this NPE by showing a message to the user, and log it.
