### PR TITLE
fix runtime exception when create directory

### DIFF
--- a/src/com/seafile/seadroid2/data/DataManager.java
+++ b/src/com/seafile/seadroid2/data/DataManager.java
@@ -271,7 +271,6 @@ public class DataManager {
         }
 
         if (!repoDir.mkdirs()) {
-            // stop throwing exception because it causes unexpected exit
             throw new RuntimeException("Could not create repo directory " + path);
         }
 


### PR DESCRIPTION
multi-threads request make directory operations, leads up to inconsistent state of one particular directory.
So change to synchronizedly process make directory request.
