### PR TITLE
fix maven build failed error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.seafile.seadroid2</groupId>
   <artifactId>seadroid</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.1</version>
   <packaging>apk</packaging>
   <name>seafile android client</name>
   <url>http://seafile.com</url>
@@ -19,13 +19,13 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <platform.version>4.2.2_r2</platform.version>
+    <platform.version>4.1.1.4</platform.version>
     <android.plugin.version>3.9.0-rc.2</android.plugin.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>android</groupId>
+      <groupId>com.google.android</groupId>
       <artifactId>android</artifactId>
       <scope>provided</scope>
       <version>${platform.version}</version>


### PR DESCRIPTION
### error log:

`Failed to execute goal on project seadroid: Could not resolve dependencies for project com.seafile.seadroid2:seadroid:apk:1.0.0: Failure to find android:android:jar:4.2.2_r2 in http://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced`
### solution
1. choose a available android jar version according [here](http://search.maven.org/#search%7Cgav%7C1%7Cg%3a%22com.google.android%22%20AND%20a%3a%22android%22)
2. android.jar artifacts in Maven central are available with the groupId `com.google.android`. The 4.1.1.4 version was the last com.google.android:android version uploaded to Maven Central, that's why it's the latest one you can reference using com.google.android:android. [read more](http://stackoverflow.com/questions/20975751/missing-artifact-com-google-androidandroidjar4-4-r1)
3. another solution available on [stack overflow provided by S.D](http://stackoverflow.com/questions/18416295/dependencies-dependency-version-for-com-google-androidandroidjar-is-missing)
