### PR TITLE
fix index off by one bug

### DIFF
--- a/src/com/seafile/seadroid2/ui/fragment/ReposFragment.java
+++ b/src/com/seafile/seadroid2/ui/fragment/ReposFragment.java
@@ -334,7 +334,7 @@ public class ReposFragment extends SherlockListFragment {
                     new TaskDialog.TaskDialogListener() {
                 @Override
                 public void onTaskSuccess() {
-                    onListItemClick(l, v, position - 1, id);
+                    onListItemClick(l, v, position, id);
                 }
             }, password);
 


### PR DESCRIPTION
When click to pen encrypted library, input the correct password, the 1.3.0 version navigates to the wrong library, actually it always navigates to the off-by-one index library.
