### PR TITLE
optimize Settings menu

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -243,7 +243,8 @@
     
     <string name="settings_about_title">ABOUT</string>
     <string name="settings_about_version_title">App Version</string>
-    <string name="settings_about_version_info">
+    <string name="settings_about_author_title">About Author</string>
+    <string name="settings_about_author_info">
         <![CDATA[
         <h5>Seafile Andoird Client</h5>
         <p>%s</p>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -5,11 +5,13 @@
         <Preference
                 android:key="account_info_user_key"
                 android:summary="@string/settings_account_info_load_data"
+                android:enabled="false"
                 android:title="@string/settings_account_info_title" >
         </Preference>
         <Preference
                 android:key="account_info_space_key"
                 android:summary="@string/settings_account_info_load_data"
+                android:enabled="false"
                 android:title="@string/settings_account_space_title" >
         </Preference>
         <Preference
@@ -56,6 +58,10 @@
         <Preference
             android:key="settings_about_version_key"
             android:summary="@string/settings_about_version_info"
+            android:enabled="false"
             android:title="@string/settings_about_version_title" />
+        <Preference
+                android:key="settings_about_author_key"
+                android:title="@string/settings_about_author_title" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/com/seafile/seadroid2/SettingsManager.java
+++ b/src/com/seafile/seadroid2/SettingsManager.java
@@ -52,6 +52,7 @@ public final class SettingsManager {
 
     // About tab
     public static final String SETTINGS_ABOUT_VERSION_KEY = "settings_about_version_key";
+    public static final String SETTINGS_ABOUT_AUTHOR_KEY = "settings_about_author_key";
 
     public static long lock_timestamp = 0;
     public static final long LOCK_EXPIRATION_MSECS = 5 * 60 * 1000;

--- a/src/com/seafile/seadroid2/ui/fragment/SettingsPreferenceFragment.java
+++ b/src/com/seafile/seadroid2/ui/fragment/SettingsPreferenceFragment.java
@@ -47,6 +47,7 @@ public class SettingsPreferenceFragment extends CustomPreferenceFragment impleme
     private CheckBoxPreference allowMobileConnections;
     private Preference cameraUploadRepo;
     private Preference versionName;
+    private Preference authorInfo;
     private SettingsActivity mActivity;
     private Intent cameraUploadIntent;
     private boolean isUploadEnabled;
@@ -142,13 +143,15 @@ public class SettingsPreferenceFragment extends CustomPreferenceFragment impleme
 
         // About
         versionName = findPreference(SettingsManager.SETTINGS_ABOUT_VERSION_KEY);
-        versionName.setOnPreferenceClickListener(this);
         try {
             appVersion = mActivity.getPackageManager().getPackageInfo(mActivity.getPackageName(), 0).versionName;
         } catch (NameNotFoundException e) {
             e.printStackTrace();
         }
         versionName.setSummary(appVersion);
+
+        authorInfo = findPreference(SettingsManager.SETTINGS_ABOUT_AUTHOR_KEY);
+        authorInfo.setOnPreferenceClickListener(this);
     }
 
     @Override
@@ -234,11 +237,11 @@ public class SettingsPreferenceFragment extends CustomPreferenceFragment impleme
             Intent intent = new Intent(mActivity, SeafilePathChooserActivity.class);
             intent.putExtra(EXTRA_CAMERA_UPLOAD, true);
             this.startActivityForResult(intent, SettingsManager.CHOOSE_CAMERA_UPLOAD_REPO_REQUEST);
-        } else if(preference.getKey().equals(SettingsManager.SETTINGS_ABOUT_VERSION_KEY)) {
+        } else if(preference.getKey().equals(SettingsManager.SETTINGS_ABOUT_AUTHOR_KEY)) {
             SeafileStyleDialogBuilder builder = new SeafileStyleDialogBuilder(mActivity);
             builder.setIcon(R.drawable.icon);            
             builder.setTitle(mActivity.getResources().getString(R.string.app_name));
-            builder.setMessage(Html.fromHtml(getString(R.string.settings_about_version_info, versionName)));
+            builder.setMessage(Html.fromHtml(getString(R.string.settings_about_author_info, versionName)));
             builder.show();
         }
         return true;


### PR DESCRIPTION
In Settings menu, some items only used to show info, in order to distinct  them with the functional items, make them unclickable.
