### PR TITLE
TLS protocol and cipher list improvements

### DIFF
--- a/src/com/seafile/seadroid2/SSLSeafileSocketFactory.java
+++ b/src/com/seafile/seadroid2/SSLSeafileSocketFactory.java
@@ -28,86 +28,79 @@ import javax.net.ssl.TrustManager;
  */
 public class SSLSeafileSocketFactory extends SSLSocketFactory {
 
-    private SSLContext m_ctx;
-    private String[] m_ciphers;
-    private String[] m_protocols;
+    private SSLContext context;
+    private String[] allowedCiphers;
+    private String[] allowedProtocols;
 
-    public SSLSeafileSocketFactory(KeyManager[] km, TrustManager[] tm, SecureRandom random) throws NoSuchAlgorithmException, KeyManagementException
-    {
-        m_ctx = SSLContext.getInstance("TLS");
-        m_ctx.init(km, tm, random);
+    public SSLSeafileSocketFactory(KeyManager[] km, TrustManager[] tm, SecureRandom random) throws NoSuchAlgorithmException, KeyManagementException {
+        context = SSLContext.getInstance("TLS");
+        context.init(km, tm, random);
 
-        m_protocols = GetProtocolList();
-        m_ciphers = GetCipherList();
+        allowedProtocols = getProtocolList();
+        allowedCiphers = getCipherList();
     }
 
     public String[] getDefaultCipherSuites()
     {
-        return m_ciphers;
+        return allowedCiphers;
     }
 
     public String[] getSupportedCipherSuites()
     {
-        return m_ciphers;
+        return allowedCiphers;
     }
 
-    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException
-    {
-        SSLSocketFactory factory = m_ctx.getSocketFactory();
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        SSLSocketFactory factory = context.getSocketFactory();
         SSLSocket ss = (SSLSocket)factory.createSocket(s, host, port, autoClose);
 
-        ss.setEnabledProtocols(m_protocols);
-        ss.setEnabledCipherSuites(m_ciphers);
+        ss.setEnabledProtocols(allowedProtocols);
+        ss.setEnabledCipherSuites(allowedCiphers);
 
         return ss;
     }
 
-    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException
-    {
-        SSLSocketFactory factory = m_ctx.getSocketFactory();
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        SSLSocketFactory factory = context.getSocketFactory();
         SSLSocket ss = (SSLSocket)factory.createSocket(address, port, localAddress, localPort);
 
-        ss.setEnabledProtocols(m_protocols);
-        ss.setEnabledCipherSuites(m_ciphers);
+        ss.setEnabledProtocols(allowedProtocols);
+        ss.setEnabledCipherSuites(allowedCiphers);
 
         return ss;
     }
 
-    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException
-    {
-        SSLSocketFactory factory = m_ctx.getSocketFactory();
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        SSLSocketFactory factory = context.getSocketFactory();
         SSLSocket ss = (SSLSocket)factory.createSocket(host, port, localHost, localPort);
 
-        ss.setEnabledProtocols(m_protocols);
-        ss.setEnabledCipherSuites(m_ciphers);
+        ss.setEnabledProtocols(allowedProtocols);
+        ss.setEnabledCipherSuites(allowedCiphers);
 
         return ss;
     }
 
-    public Socket createSocket(InetAddress host, int port) throws IOException
-    {
-        SSLSocketFactory factory = m_ctx.getSocketFactory();
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        SSLSocketFactory factory = context.getSocketFactory();
         SSLSocket ss = (SSLSocket)factory.createSocket(host, port);
 
-        ss.setEnabledProtocols(m_protocols);
-        ss.setEnabledCipherSuites(m_ciphers);
+        ss.setEnabledProtocols(allowedProtocols);
+        ss.setEnabledCipherSuites(allowedCiphers);
 
         return ss;
     }
 
-    public Socket createSocket(String host, int port) throws IOException
-    {
-        SSLSocketFactory factory = m_ctx.getSocketFactory();
+    public Socket createSocket(String host, int port) throws IOException {
+        SSLSocketFactory factory = context.getSocketFactory();
         SSLSocket ss = (SSLSocket)factory.createSocket(host, port);
 
-        ss.setEnabledProtocols(m_protocols);
-        ss.setEnabledCipherSuites(m_ciphers);
+        ss.setEnabledProtocols(allowedProtocols);
+        ss.setEnabledCipherSuites(allowedCiphers);
 
         return ss;
     }
 
-    protected String[] GetProtocolList()
-    {
+    protected String[] getProtocolList() {
         // don't offer SSLv2 or SSLv3
         if (Build.VERSION.SDK_INT >= 16) {
             return new String[]{ "TLSv1", "TLSv1.1", "TLSv1.2" };
@@ -116,17 +109,14 @@ public class SSLSeafileSocketFactory extends SSLSocketFactory {
         }
     }
 
-    protected String[] GetCipherList() {
-
+    protected String[] getCipherList() {
         // only allow ciphers which are still considered secure.
         // based on:
         // https://briansmith.org/browser-ciphersuites-01.html
-
         String[] preferredCiphers;
 
         // Android up to 2.2 use other names
         if (Build.VERSION.SDK_INT <= 8) {
-
             preferredCiphers = new String[] {
                     "DHE-RSA-AES128-SHA",
                     "DHE-RSA-AES256-SHA",
@@ -135,11 +125,8 @@ public class SSLSeafileSocketFactory extends SSLSocketFactory {
                     "AES256-SHA",
                     "RC4-SHA"
             };
-
         } else {
-
             preferredCiphers = new String[] {
-
                     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
                     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
                     "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
@@ -162,11 +149,10 @@ public class SSLSeafileSocketFactory extends SSLSocketFactory {
                     // RFC 5746
                     "TLS_EMPTY_RENEGOTIATION_INFO_SCSV"
             };
-
         }
 
         // now filter out any ciphers that aren't supported by this device
-        SSLSocketFactory factory = m_ctx.getSocketFactory();
+        SSLSocketFactory factory = context.getSocketFactory();
         String[] availableCiphers = factory.getSupportedCipherSuites();
         ArrayList<String> available = new ArrayList<String>(Arrays.asList(availableCiphers));
 
@@ -178,8 +164,6 @@ public class SSLSeafileSocketFactory extends SSLSocketFactory {
         }
 
         return result.toArray(new String[0]);
-
     }
-
 
 }

--- a/src/com/seafile/seadroid2/SSLSeafileSocketFactory.java
+++ b/src/com/seafile/seadroid2/SSLSeafileSocketFactory.java
@@ -1,0 +1,128 @@
+package com.seafile.seadroid2;
+
+import android.os.Build;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+
+/**
+ * Custom SSLSocketFactory.
+ *
+ * Used to manually select TLS protocol versions.
+ *
+ * based on:
+ * https://stackoverflow.com/questions/1037590/which-cipher-suites-to-enable-for-ssl-socket
+ */
+public class SSLSeafileSocketFactory extends SSLSocketFactory {
+
+    private SSLContext m_ctx;
+    private String[] m_ciphers;
+    private String[] m_protocols;
+
+    public SSLSeafileSocketFactory(KeyManager[] km, TrustManager[] tm, SecureRandom random) throws NoSuchAlgorithmException, KeyManagementException
+    {
+        m_ctx = SSLContext.getInstance("TLS");
+        m_ctx.init(km, tm, random);
+
+        m_protocols = GetProtocolList();
+        m_ciphers = GetCipherList();
+    }
+
+    public String[] getDefaultCipherSuites()
+    {
+        return m_ciphers;
+    }
+
+    public String[] getSupportedCipherSuites()
+    {
+        return m_ciphers;
+    }
+
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException
+    {
+        SSLSocketFactory factory = m_ctx.getSocketFactory();
+        SSLSocket ss = (SSLSocket)factory.createSocket(s, host, port, autoClose);
+
+        ss.setEnabledProtocols(m_protocols);
+        ss.setEnabledCipherSuites(m_ciphers);
+
+        return ss;
+    }
+
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException
+    {
+        SSLSocketFactory factory = m_ctx.getSocketFactory();
+        SSLSocket ss = (SSLSocket)factory.createSocket(address, port, localAddress, localPort);
+
+        ss.setEnabledProtocols(m_protocols);
+        ss.setEnabledCipherSuites(m_ciphers);
+
+        return ss;
+    }
+
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException
+    {
+        SSLSocketFactory factory = m_ctx.getSocketFactory();
+        SSLSocket ss = (SSLSocket)factory.createSocket(host, port, localHost, localPort);
+
+        ss.setEnabledProtocols(m_protocols);
+        ss.setEnabledCipherSuites(m_ciphers);
+
+        return ss;
+    }
+
+    public Socket createSocket(InetAddress host, int port) throws IOException
+    {
+        SSLSocketFactory factory = m_ctx.getSocketFactory();
+        SSLSocket ss = (SSLSocket)factory.createSocket(host, port);
+
+        ss.setEnabledProtocols(m_protocols);
+        ss.setEnabledCipherSuites(m_ciphers);
+
+        return ss;
+    }
+
+    public Socket createSocket(String host, int port) throws IOException
+    {
+        SSLSocketFactory factory = m_ctx.getSocketFactory();
+        SSLSocket ss = (SSLSocket)factory.createSocket(host, port);
+
+        ss.setEnabledProtocols(m_protocols);
+        ss.setEnabledCipherSuites(m_ciphers);
+
+        return ss;
+    }
+
+    protected String[] GetProtocolList()
+    {
+        // don't offer SSLv2 or SSLv3
+        if (Build.VERSION.SDK_INT >= 16) {
+            return new String[]{ "TLSv1", "TLSv1.1", "TLSv1.2" };
+        } else {
+            return new String[]{ "TLSv1" };
+        }
+    }
+
+    protected String[] GetCipherList() {
+
+        SSLSocketFactory factory = m_ctx.getSocketFactory();
+        String[] availableCiphers = factory.getSupportedCipherSuites();
+        return availableCiphers;
+
+    }
+
+
+}

--- a/src/com/seafile/seadroid2/SSLSeafileSocketFactory.java
+++ b/src/com/seafile/seadroid2/SSLSeafileSocketFactory.java
@@ -118,9 +118,66 @@ public class SSLSeafileSocketFactory extends SSLSocketFactory {
 
     protected String[] GetCipherList() {
 
+        // only allow ciphers which are still considered secure.
+        // based on:
+        // https://briansmith.org/browser-ciphersuites-01.html
+
+        String[] preferredCiphers;
+
+        // Android up to 2.2 use other names
+        if (Build.VERSION.SDK_INT <= 8) {
+
+            preferredCiphers = new String[] {
+                    "DHE-RSA-AES128-SHA",
+                    "DHE-RSA-AES256-SHA",
+                    "DHE-DSS-AES128-SHA",
+                    "AES128-SHA",
+                    "AES256-SHA",
+                    "RC4-SHA"
+            };
+
+        } else {
+
+            preferredCiphers = new String[] {
+
+                    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+                    "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+                    "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+                    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+                    "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+                    "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+                    "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+                    "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+
+                    // backward compatibility. offers no forward security.
+                    "TLS_RSA_WITH_AES_128_CBC_SHA",
+                    "TLS_RSA_WITH_AES_256_CBC_SHA",
+                    "SSL_RSA_WITH_RC4_128_SHA",
+
+                    // RFC 5746
+                    "TLS_EMPTY_RENEGOTIATION_INFO_SCSV"
+            };
+
+        }
+
+        // now filter out any ciphers that aren't supported by this device
         SSLSocketFactory factory = m_ctx.getSocketFactory();
         String[] availableCiphers = factory.getSupportedCipherSuites();
-        return availableCiphers;
+        ArrayList<String> available = new ArrayList<String>(Arrays.asList(availableCiphers));
+
+        List<String> result = new ArrayList<String>();
+        for(int i = 0; i < preferredCiphers.length; i++)
+        {
+            if(available.contains(preferredCiphers[i]))
+                result.add(preferredCiphers[i]);
+        }
+
+        return result.toArray(new String[0]);
 
     }
 

--- a/src/com/seafile/seadroid2/SSLTrustManager.java
+++ b/src/com/seafile/seadroid2/SSLTrustManager.java
@@ -17,6 +17,7 @@ import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
+import android.os.Build;
 import android.util.Log;
 
 import com.google.common.collect.ImmutableList;
@@ -94,10 +95,8 @@ public final class SSLTrustManager {
         }
 
         try {
-            SSLContext context = SSLContext.getInstance("TLS");
             TrustManager[] mgrs = getTrustManagers(account);
-            context.init(null, mgrs, new SecureRandom());
-            factory = context.getSocketFactory();
+            factory = new SSLSeafileSocketFactory(null, mgrs, new SecureRandom());
             Log.d(DEBUG_TAG, "a SSLSocketFactory is created:" + factory);
         } catch (Exception e) {
             Log.e(DEBUG_TAG, "error when create SSLSocketFactory", e);


### PR DESCRIPTION
* Enable TLS 1.1+
* Overwrite Android's default cipherlist with a more secure one.

(see patches for more detailed explanations)