### PR TITLE
SeafRepo cast SeafDirent exception

### DIFF
--- a/src/com/seafile/seadroid2/ui/fragment/ReposFragment.java
+++ b/src/com/seafile/seadroid2/ui/fragment/ReposFragment.java
@@ -352,17 +352,20 @@ public class ReposFragment extends SherlockListFragment {
 
         mRefreshType = REFRESH_ON_CLICK;
         if (nav.inRepo()) {
-            final SeafDirent dirent = (SeafDirent)adapter.getItem(position - 1);
-            if (dirent.isDir()) {
-                String currentPath = nav.getDirPath();
-                String newPath = currentPath.endsWith("/") ?
-                        currentPath + dirent.name : currentPath + "/" + dirent.name;
-                nav.setDir(newPath, dirent.id);
-                refreshView();
-                mActivity.setUpButtonTitle(dirent.name);
-            } else {
-                mActivity.onFileSelected(dirent);
-            }
+            if (adapter.getItem(position - 1) instanceof SeafDirent) {
+                final SeafDirent dirent = (SeafDirent) adapter.getItem(position - 1);
+                if (dirent.isDir()) {
+                    String currentPath = nav.getDirPath();
+                    String newPath = currentPath.endsWith("/") ?
+                            currentPath + dirent.name : currentPath + "/" + dirent.name;
+                    nav.setDir(newPath, dirent.id);
+                    refreshView();
+                    mActivity.setUpButtonTitle(dirent.name);
+                } else {
+                    mActivity.onFileSelected(dirent);
+                }
+            } else
+                return;
         } else {
             nav.setRepoID(repo.id);
             nav.setRepoName(repo.getName());


### PR DESCRIPTION
exception occurs when
1. network connetion very slow
2. navigate among repos very fast


error log
```
java.lang.ClassCastException: com.seafile.seadroid2.data.SeafRepo cannot be cast to com.seafile.seadroid2.data.SeafDirent
E/AndroidRuntime(14685): 	at com.seafile.seadroid2.ui.fragment.ReposFragment.onListItemClick(ReposFragment.java:355)
E/AndroidRuntime(14685): 	at android.support.v4.app.ListFragment$2.onItemClick(ListFragment.java:58)
E/AndroidRuntime(14685): 	at android.widget.AdapterView.performItemClick(AdapterView.java:298)
E/AndroidRuntime(14685): 	at android.widget.AbsListView.performItemClick(AbsListView.java:1139)
E/AndroidRuntime(14685): 	at android.widget.AbsListView$PerformClick.run(AbsListView.java:2856)
E/AndroidRuntime(14685): 	at android.widget.AbsListView$1.run(AbsListView.java:3619)
E/AndroidRuntime(14685): 	at android.os.Handler.handleCallback(Handler.java:800)
E/AndroidRuntime(14685): 	at android.os.Handler.dispatchMessage(Handler.java:100)
E/AndroidRuntime(14685): 	at android.os.Looper.loop(Looper.java:194)
E/AndroidRuntime(14685): 	at android.app.ActivityThread.main(ActivityThread.java:5409)
E/AndroidRuntime(14685): 	at java.lang.reflect.Method.invokeNative(Native Method)
E/AndroidRuntime(14685): 	at java.lang.reflect.Method.invoke(Method.java:525)
E/AndroidRuntime(14685): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:897)
E/AndroidRuntime(14685): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:664)
E/AndroidRuntime(14685): 	at dalvik.system.NativeStart.main(Native Method)
E/AppErrorDialog(  536): Failed to get ILowStorageHandle instance
```