### PR TITLE
fix monitor file download null pointer exception

### DIFF
--- a/src/com/seafile/seadroid2/monitor/SeafileMonitor.java
+++ b/src/com/seafile/seadroid2/monitor/SeafileMonitor.java
@@ -54,6 +54,8 @@ public class SeafileMonitor {
     public synchronized void onFileDownloaded(Account account, String repoID, String repoName,
             String pathInRepo, String localPath) {
         SeafileObserver observer = observers.get(account);
+        if (observer == null)
+            return;
         observer.watchDownloadedFile(repoID, repoName, pathInRepo, localPath);
     }
 


### PR DESCRIPTION
### How to reproduce
1. login an account
2. browser the library list, open one library in order to download a file later
3. go to overflow menu, click `Accounts` to open Accounts List
4. long press one account, delete it
5. press back button (not home up button to top left corner) to go back to the library list as described in step 2.
6. click a file to download
7. the app crashes

### Crash log
```
java.lang.NullPointerException
E/AndroidRuntime(20551): 	at com.seafile.seadroid2.monitor.SeafileMonitor.onFileDownloaded(SeafileMonitor.java:59)
E/AndroidRuntime(20551): 	at com.seafile.seadroid2.monitor.FileMonitorService$3.onReceive(FileMonitorService.java:134)
E/AndroidRuntime(20551): 	at android.support.v4.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:297)
E/AndroidRuntime(20551): 	at android.support.v4.content.LocalBroadcastManager.access$000(LocalBroadcastManager.java:46)
E/AndroidRuntime(20551): 	at android.support.v4.content.LocalBroadcastManager$1.handleMessage(LocalBroadcastManager.java:116)
E/AndroidRuntime(20551): 	at android.os.Handler.dispatchMessage(Handler.java:102)
E/AndroidRuntime(20551): 	at android.os.Looper.loop(Looper.java:136)
E/AndroidRuntime(20551): 	at android.app.ActivityThread.main(ActivityThread.java:5139)
E/AndroidRuntime(20551): 	at java.lang.reflect.Method.invokeNative(Native Method)
E/AndroidRuntime(20551): 	at java.lang.reflect.Method.invoke(Method.java:515)
E/AndroidRuntime(20551): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:796)
E/AndroidRuntime(20551): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:612)
E/AndroidRuntime(20551): 	at dalvik.system.NativeStart.main(Native Method)
```

### Caused by
```
public synchronized void onFileDownloaded(Account account, String repoID, String repoName,
            String pathInRepo, String localPath) {
        SeafileObserver observer = observers.get(account);
        observer.watchDownloadedFile(repoID, repoName, pathInRepo, localPath);
    }
```
the observer is null after user delete the related account configuration. To avoid this, explicitly check the overseer if it is null.
