### PR TITLE
fix certificate null pointer exception

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -166,6 +166,7 @@
     <string name="period_of_validity">Period of Validity</string>
     <string name="sha1">SHA-1 %s</string>
     <string name="md5">MD5 %s</string>
+    <string name="not_available">not available</string>
     <string name="serial_number">Serial number %s</string>
     <string name="not_before">Valid from %s</string>
     <string name="not_after">Valid until %s</string>

--- a/src/com/seafile/seadroid2/ui/dialog/SslConfirmDialog.java
+++ b/src/com/seafile/seadroid2/ui/dialog/SslConfirmDialog.java
@@ -90,15 +90,26 @@ public class SslConfirmDialog extends DialogFragment {
             msg = getActivity().getString(R.string.ssl_confirm_cert_changed, host);
         }
         messageText.setText(msg);
-        CertificateInfo certInfo = new CertificateInfo(cert);
-        commonNameText.setText(certInfo.getSubjectName());
-        // String[] subjAltNames = certInfo.getSubjectAltNames();
-        // altSubjNamesText.setText((subjAltNames.length > 0) ? StringUtils.join(subjAltNames, ", ") : "—");
-        sha1Text.setText(getActivity().getString(R.string.sha1, certInfo.getSignature("SHA-1")));
-        md5Text.setText(getActivity().getString(R.string.md5, certInfo.getSignature("MD5")));
-        serialNumberText.setText(getActivity().getString(R.string.serial_number, certInfo.getSerialNumber()));
-        notBeforeText.setText(getActivity().getString(R.string.not_before, certInfo.getNotBefore().toLocaleString()));
-        notAfterText.setText(getActivity().getString(R.string.not_after, certInfo.getNotAfter().toLocaleString()));
+
+        if (cert != null) {
+            CertificateInfo certInfo = new CertificateInfo(cert);
+            commonNameText.setText(certInfo.getSubjectName());
+            // String[] subjAltNames = certInfo.getSubjectAltNames();
+            // altSubjNamesText.setText((subjAltNames.length > 0) ? StringUtils.join(subjAltNames, ", ") : "—");
+            sha1Text.setText(getActivity().getString(R.string.sha1, certInfo.getSignature("SHA-1")));
+            md5Text.setText(getActivity().getString(R.string.md5, certInfo.getSignature("MD5")));
+            serialNumberText.setText(getActivity().getString(R.string.serial_number, certInfo.getSerialNumber()));
+            notBeforeText.setText(getActivity().getString(R.string.not_before, certInfo.getNotBefore().toLocaleString()));
+            notAfterText.setText(getActivity().getString(R.string.not_after, certInfo.getNotAfter().toLocaleString()));
+        } else {
+            String not_available = getActivity().getString(R.string.not_available);
+            commonNameText.setText(not_available);
+            sha1Text.setText(not_available);
+            md5Text.setText(not_available);
+            serialNumberText.setText(not_available);
+            notBeforeText.setText(not_available);
+            notAfterText.setText(not_available);
+        }
 
         builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
             @Override


### PR DESCRIPTION
This exception occurs when failed to get CertificateInfo (null pointer) for an specific account at runtime. 
In this case, SslConfirmDialog can\`t show the certificate details info.

### error log
```
java.lang.NullPointerException: Attempt to invoke virtual method 'javax.security.auth.x500.X500Principal java.security.cert.X509Certificate.getSubjectX500Principal()' on a null object reference
at com.seafile.seadroid2.data.CertificateInfo.getSubjectName(CertificateInfo.java:40)
at com.seafile.seadroid2.ui.dialog.SslConfirmDialog.onCreateDialog(SslConfirmDialog.java:94)
at android.support.v4.app.DialogFragment.getLayoutInflater(DialogFragment.java:295)
at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:925)
at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1102)
at android.support.v4.app.BackStackRecord.run(BackStackRecord.java:682)
at android.support.v4.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:1458)
at android.support.v4.app.FragmentManagerImpl$1.run(FragmentManager.java:438)
at android.os.Handler.handleCallback(Handler.java:739)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:135)
at android.app.ActivityThread.main(ActivityThread.java:5221)
at java.lang.reflect.Method.invoke(Native Method)
at java.lang.reflect.Method.invoke(Method.java:372)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:899)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:694)
```