### PR TITLE
show gesturelock when resume from multitask window

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -59,8 +59,7 @@
         
         <activity
             android:name="com.seafile.seadroid2.ui.activity.UnlockGesturePasswordActivity"
-            android:launchMode="singleTask"
-            android:screenOrientation="portrait" 
+            android:screenOrientation="portrait"
             android:theme="@style/Theme.SeafileTheme"
             android:label="@string/app_name" />
         

--- a/THIRD_PARTY_LICENSE.md
+++ b/THIRD_PARTY_LICENSE.md
@@ -48,3 +48,7 @@ The third party software included and used by this project is:
    Licensed under the GNU Affero General Public License, Version 3.0.  
    Placed at package com.seafile.seadroid2.provider.  
    See https://github.com/forouher/seadroid/tree/feature/documentprovider
+
+ * App passcode library for Android, master branch
+   Dual licensed under MIT, and GPL.
+   See https://github.com/wordpress-mobile/Android-PasscodeLock

--- a/src/com/seafile/seadroid2/SeadroidApplication.java
+++ b/src/com/seafile/seadroid2/SeadroidApplication.java
@@ -12,6 +12,7 @@ import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
 import com.nostra13.universalimageloader.core.assist.QueueProcessingType;
 import com.seafile.seadroid2.avatar.AuthImageDownloader;
 import com.seafile.seadroid2.data.DataManager;
+import com.seafile.seadroid2.gesturelock.AppLockManager;
 
 public class SeadroidApplication extends Application {
     private static Context context;
@@ -20,6 +21,9 @@ public class SeadroidApplication extends Application {
         super.onCreate();
         SeadroidApplication.context = getApplicationContext();
         initImageLoader(getApplicationContext());
+
+        // set gesture lock if available
+        AppLockManager.getInstance().enableDefaultAppLockIfAvailable(this);
     }
     
     public static Context getAppContext() {

--- a/src/com/seafile/seadroid2/gesturelock/AbstractAppLock.java
+++ b/src/com/seafile/seadroid2/gesturelock/AbstractAppLock.java
@@ -1,0 +1,17 @@
+/*
+ * App passcode library for Android, master branch
+ * Dual licensed under MIT, and GPL.
+ * See https://github.com/wordpress-mobile/Android-PasscodeLock
+ */
+package com.seafile.seadroid2.gesturelock;
+
+import android.app.Application;
+
+/**
+ * Abstract AppLock
+ */
+public abstract class AbstractAppLock implements Application.ActivityLifecycleCallbacks {
+
+    public abstract void enable();
+    public abstract void disable();
+}

--- a/src/com/seafile/seadroid2/gesturelock/AppLockManager.java
+++ b/src/com/seafile/seadroid2/gesturelock/AppLockManager.java
@@ -1,0 +1,31 @@
+/*
+ * App passcode library for Android, master branch
+ * Dual licensed under MIT, and GPL.
+ * See https://github.com/wordpress-mobile/Android-PasscodeLock
+ */
+package com.seafile.seadroid2.gesturelock;
+
+import android.app.Application;
+
+/**
+ * AppLock Manager
+ */
+public class AppLockManager {
+
+    private static AppLockManager instance;
+    private AbstractAppLock currentAppLocker;
+
+    public static AppLockManager getInstance() {
+        if (instance == null) {
+            instance = new AppLockManager();
+        }
+        return instance;
+    }
+
+    public void enableDefaultAppLockIfAvailable(Application currentApp) {
+        if (android.os.Build.VERSION.SDK_INT >= 14) {
+            currentAppLocker = new DefaultAppLock(currentApp);
+            currentAppLocker.enable();
+        }
+    }
+}

--- a/src/com/seafile/seadroid2/gesturelock/DefaultAppLock.java
+++ b/src/com/seafile/seadroid2/gesturelock/DefaultAppLock.java
@@ -1,0 +1,129 @@
+/*
+ * App passcode library for Android, master branch
+ * Dual licensed under MIT, and GPL.
+ * See https://github.com/wordpress-mobile/Android-PasscodeLock
+ */
+package com.seafile.seadroid2.gesturelock;
+
+import android.app.Activity;
+import android.app.Application;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import com.google.common.collect.MapMaker;
+import com.google.common.collect.Maps;
+import com.seafile.seadroid2.SettingsManager;
+import com.seafile.seadroid2.ui.activity.UnlockGesturePasswordActivity;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Implementation of AppLock
+ */
+public class DefaultAppLock extends AbstractAppLock {
+    public static final String DEBUG_TAG = "DefaultAppLock";
+
+    private Application currentApp; //Keep a reference to the app that invoked the locker
+    private SettingsManager settingsMgr;
+    private static ConcurrentMap<Object, Long> mCheckedActivities = new MapMaker()
+            .weakKeys()
+            .makeMap();
+
+    public DefaultAppLock(Application currentApp) {
+        super();
+        this.currentApp = currentApp;
+        this.settingsMgr = SettingsManager.instance();
+    }
+
+    public void enable() {
+        if (android.os.Build.VERSION.SDK_INT < 14)
+            return;
+
+        if (isPasswordLocked()) {
+            currentApp.unregisterActivityLifecycleCallbacks(this);
+            currentApp.registerActivityLifecycleCallbacks(this);
+        }
+    }
+
+    @Override
+    public void disable() {
+        if (android.os.Build.VERSION.SDK_INT < 14)
+            return;
+
+        currentApp.unregisterActivityLifecycleCallbacks(this);
+    }
+
+    //Check if we need to show the lock screen at startup
+    public boolean isPasswordLocked() {
+        return SettingsManager.instance().isGestureLockEnabled();
+    }
+
+    @Override
+    public void onActivityPaused(Activity activity) {
+        Log.d(DEBUG_TAG, "onActivityPaused");
+
+        if (activity.getClass() == UnlockGesturePasswordActivity.class)
+            return;
+
+        if (!isActiviyBeingChecked(activity)) {
+            settingsMgr.saveGestureLockTimeStamp();
+        }
+    }
+
+    private boolean isActiviyBeingChecked(Activity activity) {
+        if (!mCheckedActivities.containsKey(activity)) {
+            return false;
+        }
+        long ts = mCheckedActivities.get(activity);
+        return ts + 2000 > System.currentTimeMillis();
+    }
+
+    @Override
+    public void onActivityResumed(Activity activity) {
+        Log.d(DEBUG_TAG, "onActivityResumed");
+
+        if (activity.getClass() == UnlockGesturePasswordActivity.class)
+            return;
+
+        if (mustShowUnlockSceen()) {
+            mCheckedActivities.put(activity, System.currentTimeMillis());
+            Intent i = new Intent(activity, UnlockGesturePasswordActivity.class);
+            activity.startActivity(i);
+        }
+
+    }
+
+    private boolean mustShowUnlockSceen() {
+
+        return settingsMgr.isGestureLockRequired();
+    }
+
+
+    @Override
+    public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+
+    }
+
+    @Override
+    public void onActivityStarted(Activity activity) {
+
+    }
+
+    @Override
+    public void onActivityStopped(Activity activity) {
+
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+
+    }
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+
+    }
+}

--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -449,11 +449,6 @@ public class BrowserActivity extends SherlockFragmentActivity
         Log.d(DEBUG_TAG, "onStart");
         super.onStart();
 
-        if (SettingsManager.instance().isGestureLockRequired()) {
-            Intent intent = new Intent(this, UnlockGesturePasswordActivity.class);
-            startActivity(intent);
-        }
-
         if (mTransferReceiver == null) {
             mTransferReceiver = new TransferReceiver();
         }

--- a/src/com/seafile/seadroid2/ui/activity/SeafilePathChooserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/SeafilePathChooserActivity.java
@@ -161,15 +161,6 @@ public class SeafilePathChooserActivity extends SherlockFragmentActivity {
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-        if (SettingsManager.instance().isGestureLockRequired()) {
-            Intent newIntent = new Intent(this, UnlockGesturePasswordActivity.class);
-            startActivity(newIntent);
-        }
-    }
-
-    @Override
     protected void onDestroy() {
         Log.d(DEBUG_TAG, "onDestroy is called");
 


### PR DESCRIPTION
Unfortunately there is no an elegant way to intercept the activity life cycle methods except by having all activities extend some base class. But this is not ideal - activity hierarchy will be too messy. [as mentioned from here](https://github.com/BoD/android-activitylifecyclecallbacks-compat).

This PR mainly based on [Android-PasscodeLock](https://github.com/wordpress-mobile/Android-PasscodeLock) from [wordpress-mobile](https://github.com/wordpress-mobile). As a workaround it only support Android API 14 upwards.