### PR TITLE
fix load avatart null pointer

### DIFF
--- a/src/com/seafile/seadroid2/ui/activity/AccountsActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/AccountsActivity.java
@@ -360,6 +360,9 @@ public class AccountsActivity extends SherlockFragmentActivity {
                 }
 
                 Avatar avatar = avatarManager.parseAvatar(avatarRawData);
+                if (avatar == null)
+                    continue;
+
                 avatar.setSignature(account.getSignature());
 
                 avatars.add(avatar);


### PR DESCRIPTION
fix load avatar null pointer #251 

this exception occurs when server did\`t response.
to fix it, skip the error and continue to process next.