### PR TITLE
bind service in onStart

### DIFF
--- a/src/com/seafile/seadroid2/ui/fragment/TransferTaskFragment.java
+++ b/src/com/seafile/seadroid2/ui/fragment/TransferTaskFragment.java
@@ -68,9 +68,6 @@ public abstract class TransferTaskFragment extends SherlockListFragment {
         // Toast.makeText(mActivity, "Loading animations", Toast.LENGTH_LONG).show();
         showLoading(true);
 
-        // bind transfer service
-        Intent bIntent = new Intent(mActivity, TransferService.class);
-        mActivity.bindService(bIntent, mConnection, Context.BIND_AUTO_CREATE);
     }
 
     private ServiceConnection mConnection = new ServiceConnection() {
@@ -104,6 +101,14 @@ public abstract class TransferTaskFragment extends SherlockListFragment {
         super.onResume();
         mTransferTaskListView.setVisibility(View.GONE);
         emptyView.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        // bind transfer service
+        Intent bIntent = new Intent(mActivity, TransferService.class);
+        mActivity.bindService(bIntent, mConnection, Context.BIND_AUTO_CREATE);
     }
 
     protected abstract boolean isNeedUpdateProgress();


### PR DESCRIPTION
fix transfer task list empty when unlock the screen bug.
### References
* If your Activity wants to be interacting with the Service the entire time it is running (for example maybe it can retrieve some data from a network for you and will return the data when ready and you want to allow this to happen while in the background so if the user returns you will have the data ready), then onCreate()/onDestroy() is probably appropriate. Note that the semantics here is that the entire time your Activity is running it needs the Service, so if this Service is running in another process then you have increased the weight of it and made it more likely for it to be killed while in the background.

* If your Activity is only interested in working with the  Service while visible, then onStart()/onStop() is appropriate. This means your Activity will unbind from the Service when the user leaves it (and it is no longer visible) and connect back up the next time the return and it is re-started and resumed.

FYI, [Binding to Service](http://stackoverflow.com/a/2304794/4510876)