### PR TITLE
Disable insecure RC4 cyphersuites

### DIFF
--- a/src/com/seafile/seadroid2/SSLSeafileSocketFactory.java
+++ b/src/com/seafile/seadroid2/SSLSeafileSocketFactory.java
@@ -122,8 +122,7 @@ public class SSLSeafileSocketFactory extends SSLSocketFactory {
                     "DHE-RSA-AES256-SHA",
                     "DHE-DSS-AES128-SHA",
                     "AES128-SHA",
-                    "AES256-SHA",
-                    "RC4-SHA"
+                    "AES256-SHA"
             };
         } else {
             preferredCiphers = new String[] {
@@ -138,13 +137,10 @@ public class SSLSeafileSocketFactory extends SSLSocketFactory {
                     "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
                     "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
                     "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
-                    "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
-                    "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
 
                     // backward compatibility. offers no forward security.
                     "TLS_RSA_WITH_AES_128_CBC_SHA",
                     "TLS_RSA_WITH_AES_256_CBC_SHA",
-                    "SSL_RSA_WITH_RC4_128_SHA",
 
                     // RFC 5746
                     "TLS_EMPTY_RENEGOTIATION_INFO_SCSV"


### PR DESCRIPTION
RFC 7465 recommends to not use RC4 cyphers anymore.
Firefox 36+ disables it as well (https://www.mozilla.org/en-US/firefox/36.0/releasenotes/).

This patch removes all RC4 cyphersuites from the list offered to the server.