### PR TITLE
Document Provider: Write support and other changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ jdk:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq libstdc++6:i386 lib32z1 expect
-  - wget http://dl.google.com/android/android-sdk_r23.0.2-linux.tgz
-  - tar xf android-sdk_r23.0.2-linux.tgz
+  - wget http://dl.google.com/android/android-sdk_r24.0.2-linux.tgz
+  - tar xf android-sdk_r24.0.2-linux.tgz
   - export ANDROID_HOME=`pwd`/android-sdk-linux
   - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
-  - echo "y" | android update sdk -a --filter tools,platform-tools,build-tools-20.0.0,android-19 --no-ui --force
+  - echo "y" | android update sdk -a --filter tools,platform-tools,build-tools-21.1.2,android-21 --no-ui --force
   - cd /tmp/
   - git clone https://github.com/mosabua/maven-android-sdk-deployer.git
   - cd maven-android-sdk-deployer
-  - mvn clean install -pl platforms/android-19
+  - mvn clean install -pl platforms/android-21
   - cd $TRAVIS_BUILD_DIR
 script:
   - mvn test

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,7 +4,7 @@
       android:versionCode="30"
       android:versionName="1.5.1">
 
-    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="19" />
+    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="21" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [Contributors Graph](https://github.com/haiwen/seadroid/graphs/contributors)
 ```
 export ANDROID_HOME=<android SDK location>
 export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
-echo "y" | android update sdk -a --filter tools,platform-tools,build-tools-20.0.0,android-19 --no-ui --force
+echo "y" | android update sdk -a --filter tools,platform-tools,build-tools-21.1.2,android-21 --no-ui --force
 ```
 
 * Install [Maven Android SDK Deployer](https://github.com/simpligility/maven-android-sdk-deployer) with:
@@ -27,7 +27,7 @@ echo "y" | android update sdk -a --filter tools,platform-tools,build-tools-20.0.
 cd /tmp/
 git clone https://github.com/mosabua/maven-android-sdk-deployer.git
 cd maven-android-sdk-deployer
-mvn clean install -pl platforms/android-19
+mvn clean install -pl platforms/android-21
 ```
 
 * Return in `seadroid` directory and build the APK with:

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <platform.version>4.4.2_r4</platform.version>
+    <platform.version>5.0.1_r2</platform.version>
     <android.plugin.version>3.9.0-rc.2</android.plugin.version>
   </properties>
 
@@ -116,7 +116,7 @@
         <artifactId>android-maven-plugin</artifactId>
         <configuration>
           <sdk>
-            <platform>19</platform>
+            <platform>21</platform>
           </sdk>
           <proguard>
             <skip>false</skip>

--- a/project.properties
+++ b/project.properties
@@ -11,7 +11,7 @@
 proguard.config=${sdk.dir}/tools/proguard/proguard-android.txt:proguard-project.txt
 
 # Project target.
-target=android-19
+target=android-21
 android.library.reference.1=../ActionBarSherlock-4.4.0/actionbarsherlock
 android.library.reference.2=../Android-ViewPagerIndicator/pagerlibrary
 android.library.reference.3=../NewQuickAction

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -302,6 +302,8 @@
     <string name="saf_account_not_found_exception">Couldn\'t find Seafile account.</string>
     <string name="saf_upload_path_not_available">Unable to upload, no path available</string>
     <string name="saf_failed_to_create_directory">Could not create directory %s</string>
+    <string name="saf_file_exist">File exists already</string>
+    <string name="saf_bad_mime_type">Bad request type</string>
 
     <!-- shibboleth SSO -->
     <string name="shib_server_url_empty">Server is empty!</string>

--- a/src/com/seafile/seadroid2/SeafConnection.java
+++ b/src/com/seafile/seadroid2/SeafConnection.java
@@ -526,7 +526,7 @@ public class SeafConnection {
             if (msg != null)
                 Log.d(DEBUG_TAG, msg);
             else
-                Log.d(DEBUG_TAG, "get upload link error");
+                Log.d(DEBUG_TAG, "get upload link error", e);
             throw SeafException.unknownException;
         }
     }

--- a/src/com/seafile/seadroid2/account/Account.java
+++ b/src/com/seafile/seadroid2/account/Account.java
@@ -88,7 +88,11 @@ public class Account implements Parcelable {
     public String getSignature() {
         return email.substring(0, 4) + " " + hashCode();
     }
-    
+
+    public String getFullSignature() {
+        return email+"@"+server;
+    }
+
     public String getName() {
         return email.substring(0, email.indexOf("@")) + "@" + getServerHost();
     }

--- a/src/com/seafile/seadroid2/account/Account.java
+++ b/src/com/seafile/seadroid2/account/Account.java
@@ -90,7 +90,7 @@ public class Account implements Parcelable {
     }
 
     public String getFullSignature() {
-        return email+"@"+server;
+        return email + "@" + server;
     }
 
     public String getName() {

--- a/src/com/seafile/seadroid2/account/AccountDBHelper.java
+++ b/src/com/seafile/seadroid2/account/AccountDBHelper.java
@@ -43,6 +43,7 @@ public class AccountDBHelper extends SQLiteOpenHelper {
             return dbHelper;
         dbHelper = new AccountDBHelper(context);
         dbHelper.database = dbHelper.getWritableDatabase();
+        AccountNotifier.notifyProvider();
         return dbHelper;
     }
 

--- a/src/com/seafile/seadroid2/data/DataManager.java
+++ b/src/com/seafile/seadroid2/data/DataManager.java
@@ -473,7 +473,7 @@ public class DataManager {
     public List<SeafStarredFile> getStarredFiles() throws SeafException {
         String starredFiles = sc.getStarredFiles();
         Log.v(DEBUG_TAG, "Save starred files: " + starredFiles);
-        dbHelper.saveCachedStarredFiles(account,starredFiles);
+        dbHelper.saveCachedStarredFiles(account, starredFiles);
         return parseStarredFiles(starredFiles);
     }
 

--- a/src/com/seafile/seadroid2/data/SeafStarredFile.java
+++ b/src/com/seafile/seadroid2/data/SeafStarredFile.java
@@ -37,6 +37,14 @@ public class SeafStarredFile implements SeafItem {
         }
     }
 
+    public long getSize() {
+        return size;
+    }
+
+    public long getMtime() {
+        return mtime;
+    }
+
     public boolean isDir() {
         return (type == FileType.DIR);
     }

--- a/src/com/seafile/seadroid2/provider/DocumentIdParser.java
+++ b/src/com/seafile/seadroid2/provider/DocumentIdParser.java
@@ -94,7 +94,8 @@ public class DocumentIdParser {
         String[] list = documentId.split(DOC_SEPERATOR, 3);
         if (list.length>2) {
             String path = list[2];
-            return path;
+            if (path.length()>0)
+                return path;
         }
         return ProviderUtil.PATH_SEPERATOR;
     }

--- a/src/com/seafile/seadroid2/provider/DocumentIdParser.java
+++ b/src/com/seafile/seadroid2/provider/DocumentIdParser.java
@@ -39,6 +39,7 @@ public class DocumentIdParser {
 
     /** used to separate serverName, RepoId and Path. */
     private static final String DOC_SEPERATOR = "::::";
+    private static final String STARRED_FILE_REPO_ID = "starred-file-magic-repo";
 
     Context context;
 
@@ -117,4 +118,11 @@ public class DocumentIdParser {
             return a.getFullSignature();
     }
 
+    public static String buildStarredFilesId(Account a) {
+        return a.getFullSignature() + DOC_SEPERATOR + STARRED_FILE_REPO_ID;
+    }
+
+    public static boolean isStarredFiles(String documentId) {
+        return getRepoIdFromId(documentId).equals(STARRED_FILE_REPO_ID);
+    }
 }

--- a/src/com/seafile/seadroid2/provider/DocumentIdParser.java
+++ b/src/com/seafile/seadroid2/provider/DocumentIdParser.java
@@ -93,9 +93,9 @@ public class DocumentIdParser {
      */
     public static String getPathFromId(String documentId) {
         String[] list = documentId.split(DOC_SEPERATOR, 3);
-        if (list.length>2) {
+        if (list.length > 2) {
             String path = list[2];
-            if (path.length()>0)
+            if (path.length() > 0)
                 return path;
         }
         return ProviderUtil.PATH_SEPERATOR;

--- a/src/com/seafile/seadroid2/provider/DocumentIdParser.java
+++ b/src/com/seafile/seadroid2/provider/DocumentIdParser.java
@@ -19,8 +19,6 @@ package com.seafile.seadroid2.provider;
 
 import android.content.Context;
 
-import com.seafile.seadroid2.R;
-import com.seafile.seadroid2.SeadroidApplication;
 import com.seafile.seadroid2.account.Account;
 import com.seafile.seadroid2.account.AccountDBHelper;
 
@@ -65,9 +63,7 @@ public class DocumentIdParser {
                 }
             }
         }
-        throw new FileNotFoundException(SeadroidApplication.getAppContext()
-                .getResources()
-                .getString(R.string.saf_account_not_found_exception));
+        throw new FileNotFoundException();
     }
 
     /**

--- a/src/com/seafile/seadroid2/provider/DocumentIdParser.java
+++ b/src/com/seafile/seadroid2/provider/DocumentIdParser.java
@@ -40,6 +40,7 @@ public class DocumentIdParser {
     /** used to separate serverName, RepoId and Path. */
     private static final String DOC_SEPERATOR = "::::";
     private static final String STARRED_FILE_REPO_ID = "starred-file-magic-repo";
+    private static final String ROOT_REPO_ID = "root-magic-repo";
 
     Context context;
 
@@ -118,8 +119,22 @@ public class DocumentIdParser {
             return a.getFullSignature();
     }
 
+    /**
+     * create a documentId based on an account, a repoId and a file path.
+     *
+     * @param a the account object. must not be null.
+     * @returns a documentId
+     */
+    public static String buildRootId(Account a) {
+        return a.getFullSignature() + DOC_SEPERATOR + ROOT_REPO_ID;
+    }
+
     public static String buildStarredFilesId(Account a) {
         return a.getFullSignature() + DOC_SEPERATOR + STARRED_FILE_REPO_ID;
+    }
+
+    public static boolean isRoot(String documentId) {
+        return getRepoIdFromId(documentId).equals(ROOT_REPO_ID);
     }
 
     public static boolean isStarredFiles(String documentId) {

--- a/src/com/seafile/seadroid2/provider/DocumentIdParser.java
+++ b/src/com/seafile/seadroid2/provider/DocumentIdParser.java
@@ -27,9 +27,9 @@ import java.io.FileNotFoundException;
 /**
  * Helper class to create and parse DocumentIds for the DocumentProvider
  *
- * Format: ServerName::::RepoId::::Path
+ * Format: FullServerServerSignature::RepoId::Path
  * Example:
- * https://server.com/seafile/::::550e8400-e29b-11d4-a716-446655440000::::/dir/file.jpg
+ * email@adress.com@https://server.com/seafile/::::550e8400-e29b-11d4-a716-446655440000::::/dir/file.jpg
  *
  * the separation using "::::" is arbitrary. Is has to be something, that is neither in an URL
  * nor in a repoId UUID.
@@ -58,7 +58,7 @@ public class DocumentIdParser {
         if (list.length > 0) {
             String server = list[0];
             for (Account a: AccountDBHelper.getDatabaseHelper(context).getAccountList()) {
-                if (a.getServer().equals(server)) {
+                if (a.getFullSignature().equals(server)) {
                     return a;
                 }
             }
@@ -109,11 +109,11 @@ public class DocumentIdParser {
      */
     public static String buildId(Account a, String repoId, String path) {
         if (repoId != null && path != null)
-            return a.getServer() + DOC_SEPERATOR + repoId + DOC_SEPERATOR + path;
+            return a.getFullSignature() + DOC_SEPERATOR + repoId + DOC_SEPERATOR + path;
         else if (repoId != null)
-            return a.getServer() + DOC_SEPERATOR + repoId;
+            return a.getFullSignature() + DOC_SEPERATOR + repoId;
         else
-            return a.getServer();
+            return a.getFullSignature();
     }
 
 }

--- a/src/com/seafile/seadroid2/provider/ProviderUtil.java
+++ b/src/com/seafile/seadroid2/provider/ProviderUtil.java
@@ -67,8 +67,11 @@ public class ProviderUtil {
      * @returns the parent directory.
      */
     public static String getParentDirFromPath(String path) {
-        int lastSlash = path.lastIndexOf('/');
-        return path.substring(0, lastSlash);
+        int lastSlash = path.lastIndexOf(ProviderUtil.PATH_SEPERATOR);
+        if (lastSlash == 0)
+            return ProviderUtil.PATH_SEPERATOR;
+        else
+            return path.substring(0, lastSlash);
     }
 
     /**
@@ -79,7 +82,7 @@ public class ProviderUtil {
      * @returns the filename.
      */
     public static String getFileNameFromPath(String path) {
-        int lastSlash = path.lastIndexOf('/');
+        int lastSlash = path.lastIndexOf(ProviderUtil.PATH_SEPERATOR);
         return path.substring(lastSlash + 1);
     }
 

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -797,6 +797,14 @@ public class SeafileProvider extends DocumentsProvider {
                 } catch (SeafException e) {
                     Log.e(DEBUG_TAG, "Exception while querying server", e);
                 }
+
+                // The notification has to be sent only *after* queryChildDocuments has
+                // finished. To be safe, wait a bit.
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e1) {
+                }
+
                 // notify the SAF to to do a new queryChildDocuments
                 getContext().getContentResolver().notifyChange(uri, null);
             }
@@ -825,6 +833,14 @@ public class SeafileProvider extends DocumentsProvider {
                 } catch (SeafException e) {
                     Log.e(DEBUG_TAG, "Exception while querying server", e);
                 }
+
+                // The notification has to be sent only *after* queryChildDocuments has
+                // finished. To be safe, wait a bit.
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e1) {
+                }
+
                 // notify the SAF to to do a new queryChildDocuments
                 getContext().getContentResolver().notifyChange(uri, null);
             }
@@ -854,6 +870,14 @@ public class SeafileProvider extends DocumentsProvider {
                 } catch (SeafException e) {
                     Log.e(DEBUG_TAG, "Exception while querying server", e);
                 }
+
+                // The notification has to be sent only *after* queryChildDocuments has
+                // finished. To be safe, wait a bit.
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e1) {
+                }
+
                 // notify the SAF to to do a new queryChildDocuments
                 getContext().getContentResolver().notifyChange(uri, null);
             }

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -20,6 +20,10 @@
 package com.seafile.seadroid2.provider;
 
 import android.annotation.TargetApi;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
 import android.content.res.AssetFileDescriptor;
 import android.database.Cursor;
 import android.database.MatrixCursor;
@@ -30,6 +34,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.CancellationSignal;
 import android.os.Handler;
+import android.os.IBinder;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.provider.DocumentsContract.Document;
@@ -49,6 +54,7 @@ import com.seafile.seadroid2.data.ProgressMonitor;
 import com.seafile.seadroid2.data.SeafDirent;
 import com.seafile.seadroid2.data.SeafRepo;
 import com.seafile.seadroid2.data.SeafStarredFile;
+import com.seafile.seadroid2.transfer.TransferService;
 import com.seafile.seadroid2.util.Utils;
 
 import java.io.File;
@@ -110,6 +116,26 @@ public class SeafileProvider extends DocumentsProvider {
     private final BlockingQueue<Runnable> mDecodeWorkQueue = new LinkedBlockingQueue<Runnable>();
     private ThreadPoolExecutor threadPoolExecutor;
 
+    private TransferService txService = null;
+
+    private ServiceConnection mConnection = new ServiceConnection() {
+        @Override
+        public void onServiceConnected(ComponentName className, IBinder service) {
+            TransferService.TransferBinder binder = (TransferService.TransferBinder) service;
+
+            synchronized (this) {
+                txService = binder.getService();
+                notifyAll();
+            }
+            Log.d(DEBUG_TAG, "bind TransferService");
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName arg0) {
+            txService = null;
+        }
+    };
+
     @Override
     public boolean onCreate() {
         docIdParser = new DocumentIdParser(getContext());
@@ -120,6 +146,10 @@ public class SeafileProvider extends DocumentsProvider {
                 KEEP_ALIVE_TIME,
                 KEEP_ALIVE_TIME_UNIT,
                 mDecodeWorkQueue);
+
+        Intent bIntent = new Intent(getContext(), TransferService.class);
+        getContext().bindService(bIntent, mConnection, Context.BIND_AUTO_CREATE);
+        Log.d(DEBUG_TAG, "try bind TransferService");
 
         return true;
     }
@@ -540,11 +570,26 @@ public class SeafileProvider extends DocumentsProvider {
                             @Override
                             public void run() {
                                 try {
-                                    dm.updateFile(repoName, repoID, parentDir, file.getPath(), null, false);
+
+                                    // wait for the service to bind
+                                    synchronized (mConnection) {
+                                        if (txService == null)
+                                            mConnection.wait();
+                                    }
+
+                                    txService.addTaskToUploadQue(dm.getAccount(),
+                                            repoID,
+                                            repoName,
+                                            parentDir,
+                                            file.getPath(),
+                                            true,
+                                            false);
 
                                     // update cache for parent dir
                                     dm.getDirentsFromServer(repoID, parentDir);
                                 } catch (SeafException e1) {
+                                    Log.d(DEBUG_TAG, "could not upload file: ", e1);
+                                } catch (InterruptedException e1) {
                                     Log.d(DEBUG_TAG, "could not upload file: ", e1);
                                 }
                             }

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -76,6 +76,7 @@ import java.util.concurrent.TimeUnit;
  */
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class SeafileProvider extends DocumentsProvider {
+    public static final String DEBUG_TAG = "SeafileProvider";
 
     private static final String[] SUPPORTED_ROOT_PROJECTION = new String[] {
             Root.COLUMN_ROOT_ID,
@@ -131,7 +132,7 @@ public class SeafileProvider extends DocumentsProvider {
                 netProjection(projection, SUPPORTED_ROOT_PROJECTION);
         MatrixCursor result=new MatrixCursor(netProjection);
 
-        Log.d(getClass().getSimpleName(), "queryRoots()");
+        Log.d(DEBUG_TAG, "queryRoots()");
 
         // add a Root for every Seafile account we have.
         for(Account a: AccountDBHelper.getDatabaseHelper(getContext()).getAccountList()) {
@@ -150,7 +151,7 @@ public class SeafileProvider extends DocumentsProvider {
                                       String sortOrder)
             throws FileNotFoundException {
 
-        Log.d(getClass().getSimpleName(), "queryChildDocuments: " + parentDocumentId);
+        Log.d(DEBUG_TAG, "queryChildDocuments: " + parentDocumentId);
 
         String[] netProjection = 
                 netProjection(projection, SUPPORTED_DOCUMENT_PROJECTION);
@@ -247,7 +248,7 @@ public class SeafileProvider extends DocumentsProvider {
     @Override
     public Cursor queryDocument(String documentId, String[] projection) throws FileNotFoundException {
 
-        Log.d(getClass().getSimpleName(), "queryDocument: " + documentId);
+        Log.d(DEBUG_TAG, "queryDocument: " + documentId);
 
         String[] netProjection = 
                 netProjection(projection, SUPPORTED_DOCUMENT_PROJECTION);
@@ -350,10 +351,10 @@ public class SeafileProvider extends DocumentsProvider {
             return future.get();
 
         } catch (InterruptedException e) {
-            Log.d(getClass().getSimpleName(), "could not open file", e);
+            Log.d(DEBUG_TAG, "could not open file", e);
             throw new FileNotFoundException();
         } catch (ExecutionException e) {
-            Log.d(getClass().getSimpleName(), "could not open file", e);
+            Log.d(DEBUG_TAG, "could not open file", e);
             throw new FileNotFoundException();
         }
     }
@@ -410,7 +411,7 @@ public class SeafileProvider extends DocumentsProvider {
                         fileStream.close();
 
                     } catch (IOException e) {
-                        Log.d(getClass().getSimpleName(), "could not transfer thumbnail.");
+                        Log.d(DEBUG_TAG, "could not transfer thumbnail.");
                     }
                 }
 
@@ -419,14 +420,14 @@ public class SeafileProvider extends DocumentsProvider {
             return new AssetFileDescriptor(pair[0], 0, AssetFileDescriptor.UNKNOWN_LENGTH);
 
         } catch (IOException e) {
-            Log.d(getClass().getSimpleName(), "could not fetch thumbnail", e);
+            Log.d(DEBUG_TAG, "could not fetch thumbnail", e);
             throw new FileNotFoundException();
         }
     }
 
     @Override
     public String createDocument (String parentDocumentId, String mimeType, String displayName) throws FileNotFoundException {
-        Log.d(getClass().getSimpleName(), "createDocument: " + parentDocumentId + "; " + mimeType + "; " + displayName);
+        Log.d(DEBUG_TAG, "createDocument: " + parentDocumentId + "; " + mimeType + "; " + displayName);
 
         String repoId = DocumentIdParser.getRepoIdFromId(parentDocumentId);
         if (repoId.isEmpty()) {
@@ -466,7 +467,7 @@ public class SeafileProvider extends DocumentsProvider {
             return DocumentIdParser.buildId(dm.getAccount(), repoId, Utils.pathJoin(parentPath, displayName));
 
         } catch (SeafException e) {
-            Log.d(getClass().getSimpleName(), "could not create file/dir", e);
+            Log.d(DEBUG_TAG, "could not create file/dir", e);
             throw new FileNotFoundException();
         }
     }
@@ -508,7 +509,7 @@ public class SeafileProvider extends DocumentsProvider {
                 new ParcelFileDescriptor.OnCloseListener() {
                     @Override
                     public void onClose(final IOException e) {
-                        Log.d(getClass().getSimpleName(), "uploading file: " + repoID + "; " + file.getPath() + "; " + parentDir + "; e="+e);
+                        Log.d(DEBUG_TAG, "uploading file: " + repoID + "; " + file.getPath() + "; " + parentDir + "; e="+e);
 
                         if (mode.equals("r") || e != null) {
                             return;
@@ -523,7 +524,7 @@ public class SeafileProvider extends DocumentsProvider {
                                     // update cache for parent dir
                                     dm.getDirentsFromServer(repoID, parentDir);
                                 } catch (SeafException e1) {
-                                    Log.d(getClass().getSimpleName(), "could not upload file: ", e1);
+                                    Log.d(DEBUG_TAG, "could not upload file: ", e1);
                                 }
                             }
                         });

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -113,7 +113,7 @@ public class SeafileProvider extends DocumentsProvider {
 
             row.add(Root.COLUMN_ROOT_ID, a.getServerHost());
             row.add(Root.COLUMN_ICON, R.drawable.ic_launcher);
-            row.add(Root.COLUMN_FLAGS, 0);
+            row.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_IS_CHILD);
             row.add(Root.COLUMN_TITLE, a.getName());
             row.add(Root.COLUMN_DOCUMENT_ID, a.getServer());
         }
@@ -248,6 +248,11 @@ public class SeafileProvider extends DocumentsProvider {
 
 
         return(result);
+    }
+
+    @Override
+    public boolean isChildDocument(String parentId, String documentId) {
+        return documentId.startsWith(parentId);
     }
 
     @Override

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -65,6 +65,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -392,6 +393,9 @@ public class SeafileProvider extends DocumentsProvider {
         } catch (InterruptedException e) {
             Log.d(DEBUG_TAG, "openDocument cancelled download");
             throw new FileNotFoundException();
+        } catch (CancellationException e) {
+            Log.d(DEBUG_TAG, "openDocumentThumbnail cancelled download");
+            throw new FileNotFoundException();
         } catch (ExecutionException e) {
             Log.d(DEBUG_TAG, "could not open file", e);
             throw new FileNotFoundException();
@@ -468,6 +472,9 @@ public class SeafileProvider extends DocumentsProvider {
         try {
             return future.get();
         } catch (InterruptedException e) {
+            Log.d(DEBUG_TAG, "openDocumentThumbnail cancelled download");
+            throw new FileNotFoundException();
+        } catch (CancellationException e) {
             Log.d(DEBUG_TAG, "openDocumentThumbnail cancelled download");
             throw new FileNotFoundException();
         } catch (ExecutionException e) {

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -103,8 +103,8 @@ public class SeafileProvider extends DocumentsProvider {
                     Document.COLUMN_SUMMARY
             };
     
-    /** we remember the last documentId queried so we don't run into a loop while doing Async lookups. */
-    private String lastQueriedDocumentId = null;
+    /** this flag is used to avoid infinite loops due to background refreshes */
+    private boolean returnCachedData = false;
 
     private DocumentIdParser docIdParser;
 
@@ -175,14 +175,13 @@ public class SeafileProvider extends DocumentsProvider {
             MatrixCursor result;
 
             // fetch a new repo list in the background
-            if (!parentDocumentId.equals(lastQueriedDocumentId)) {
+            if (!returnCachedData) {
                 result = createCursor(netProjection, true, isReachable.get(dm.getAccount()));
-                lastQueriedDocumentId = parentDocumentId;
-
+                returnCachedData = true;
                 fetchReposAsync(dm, result);
-
             } else {
                 result = createCursor(netProjection, false, isReachable.get(dm.getAccount()));
+                returnCachedData = false;
             }
 
             // in the meantime, return the cached repos
@@ -199,13 +198,13 @@ public class SeafileProvider extends DocumentsProvider {
             // the user is asking for the list of starred files
 
             MatrixCursor result;
-            if (!parentDocumentId.equals(lastQueriedDocumentId)) {
+            if (!returnCachedData) {
                 result = createCursor(netProjection, true, isReachable.get(dm.getAccount()));
-                lastQueriedDocumentId = parentDocumentId;
+                returnCachedData = true;
                 fetchStarredAsync(dm, result);
             } else {
                 result = createCursor(netProjection, false, isReachable.get(dm.getAccount()));
-
+                returnCachedData = false;
             }
 
             List<SeafStarredFile> starredFiles = dm.getCachedStarredFiles();
@@ -230,14 +229,13 @@ public class SeafileProvider extends DocumentsProvider {
             MatrixCursor result;
 
             // fetch new dirents in the background
-            if (!parentDocumentId.equals(lastQueriedDocumentId)) {
-
-                lastQueriedDocumentId = parentDocumentId;
+            if (!returnCachedData) {
                 result = createCursor(netProjection, true, isReachable.get(dm.getAccount()));
+                returnCachedData = true;
                 fetchDirentAsync(dm, repoId, path, result);
-
             } else {
                 result = createCursor(netProjection, false, isReachable.get(dm.getAccount()));
+                returnCachedData = false;
             }
 
             // in the meantime return cached ones

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -326,6 +326,9 @@ public class SeafileProvider extends DocumentsProvider {
                                              final CancellationSignal signal)
             throws FileNotFoundException {
 
+        if (!Utils.isNetworkOn())
+            throw new FileNotFoundException();
+
         // open the file. this might involve talking to the seafile server. this will hang until
         // it is done.
         final Future<ParcelFileDescriptor> future = threadPoolExecutor.submit(new Callable<ParcelFileDescriptor>() {
@@ -452,6 +455,9 @@ public class SeafileProvider extends DocumentsProvider {
     @Override
     public String createDocument (String parentDocumentId, String mimeType, String displayName) throws FileNotFoundException {
         Log.d(DEBUG_TAG, "createDocument: " + parentDocumentId + "; " + mimeType + "; " + displayName);
+
+        if (!Utils.isNetworkOn())
+            throw new FileNotFoundException();
 
         String repoId = DocumentIdParser.getRepoIdFromId(parentDocumentId);
         if (repoId.isEmpty()) {

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -261,9 +261,9 @@ public class SeafileProvider extends DocumentsProvider {
 
         String repoId = DocumentIdParser.getRepoIdFromId(documentId);
         if (repoId.isEmpty()) {
-            // the user has asked for the root, that contains all the repositories as children.
+            // the user has asked for the base document_id for a root
 
-            includeRoot(result, dm.getAccount());
+            includeDocIdRoot(result, dm.getAccount());
             return result;
         }
 
@@ -628,15 +628,35 @@ public class SeafileProvider extends DocumentsProvider {
      */
     private void includeRoot(MatrixCursor result, Account account) {
         String docId = DocumentIdParser.buildId(account, null, null);
+        String rootId = DocumentIdParser.buildRootId(account);
 
         final MatrixCursor.RowBuilder row = result.newRow();
 
-        row.add(Root.COLUMN_ROOT_ID, docId);
+        row.add(Root.COLUMN_ROOT_ID, rootId);
         row.add(Root.COLUMN_DOCUMENT_ID, docId);
         row.add(Root.COLUMN_ICON, R.drawable.ic_launcher);
         row.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_IS_CHILD | Root.FLAG_SUPPORTS_CREATE);
         row.add(Root.COLUMN_TITLE, account.getServerHost());
         row.add(Root.COLUMN_SUMMARY, account.getEmail());
+    }
+
+    /**
+     * Add a cursor entry for the account base document_id.
+     *
+     * @param result the cursor to write the row into.
+     * @param account the account to add.
+     */
+    private void includeDocIdRoot(MatrixCursor result, Account account) {
+        String docId = DocumentIdParser.buildId(account, null, null);
+
+        final MatrixCursor.RowBuilder row = result.newRow();
+        row.add(Document.COLUMN_DOCUMENT_ID, docId);
+        row.add(Document.COLUMN_DISPLAY_NAME,account.getServerHost());
+        row.add(Document.COLUMN_LAST_MODIFIED, null);
+        row.add(Document.COLUMN_FLAGS, 0);
+        row.add(Document.COLUMN_ICON, R.drawable.ic_launcher);
+        row.add(Document.COLUMN_SIZE, null);
+        row.add(Document.COLUMN_MIME_TYPE, Document.MIME_TYPE_DIR);
     }
 
     /**

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -68,13 +68,13 @@ import java.util.concurrent.TimeUnit;
 /**
  * DocumentProvider for the Storage Access Framework.
  *
- * It depends on API level 19.
+ * It depends on API level 19 and supports API level 21.
  *
  * This Provider gives access to other Apps to browse, read and write all files
  * contained in Seafile repositories.
  *
  */
-@TargetApi(Build.VERSION_CODES.KITKAT)
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class SeafileProvider extends DocumentsProvider {
 
     private static final String[] SUPPORTED_ROOT_PROJECTION = new String[] {

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -221,9 +221,7 @@ public class SeafileProvider extends DocumentsProvider {
             if (!parentDocumentId.equals(lastQueriedDocumentId)) {
 
                 lastQueriedDocumentId = parentDocumentId;
-
                 result = createCursor(netProjection, true);
-
                 fetchDirentAsync(dm, repoId, path, result);
 
             } else {
@@ -233,7 +231,6 @@ public class SeafileProvider extends DocumentsProvider {
             // in the meantime return cached ones
             List<SeafDirent> dirents = dm.getCachedDirents(repoId, path);
             if (dirents != null) {
-
                 for (SeafDirent d : dirents) {
                     includeDirent(result, dm, repoId, path, d);
                 }
@@ -258,7 +255,6 @@ public class SeafileProvider extends DocumentsProvider {
         String repoId = DocumentIdParser.getRepoIdFromId(documentId);
         if (repoId.isEmpty()) {
             // the user has asked for the root, that contains all the repositories as children.
-            // we don't have much to say about that "directory".
 
             includeRoot(result, dm.getAccount());
             return result;
@@ -278,13 +274,12 @@ public class SeafileProvider extends DocumentsProvider {
             // about the repository itself, not some directory in it.
             includeRepo(result, dm.getAccount(), repo);
         } else {
-            // the generic case. a query about a file/directory in a repository.
+            // the general case. a query about a file/directory in a repository.
 
             // again we only use cached info in this function. that shouldn't be an issue, as
             // very likely there has been a SeafileProvider.queryChildDocuments() call just moments
             // earlier.
 
-            // the file might not be cached. try to find the file in the dirent of its parent directory.
             String parentPath = ProviderUtil.getParentDirFromPath(path);
             List<SeafDirent> dirents = dm.getCachedDirents(repo.getID(), parentPath);
             List<SeafStarredFile> starredFiles = dm.getCachedStarredFiles();
@@ -310,8 +305,7 @@ public class SeafileProvider extends DocumentsProvider {
             }
         }
 
-
-        return(result);
+        return result;
     }
 
     @Override
@@ -324,7 +318,6 @@ public class SeafileProvider extends DocumentsProvider {
                                              String mode,
                                              final CancellationSignal signal)
             throws FileNotFoundException {
-
 
         DataManager dm = createDataManager(documentId);
 
@@ -543,6 +536,7 @@ public class SeafileProvider extends DocumentsProvider {
                                 SeafRepo repo, 
                                 String path)
             throws FileNotFoundException {
+
         try {
             // fetch the file from the Seafile server.
             File f = dm.getFile(repo.getName(), repo.getID(), path, new ProgressMonitor() {
@@ -762,8 +756,7 @@ public class SeafileProvider extends DocumentsProvider {
                 } catch (SeafException e) {
                     Log.e(getClass().getSimpleName(), "Exception while querying server", e);
                 }
-                // notify the client in any case.
-                // XXX: the API is unclear about this. we could also let him wait forever.
+                // notify the SAF to to do a new queryChildDocuments
                 getContext().getContentResolver().notifyChange(uri, null);
             }
         });
@@ -801,7 +794,7 @@ public class SeafileProvider extends DocumentsProvider {
     /**
      * Create a new DataManager (which gives us access to the Seafile cache and server).
      *
-     * @param documentId documentId, must contain at least a serverName.
+     * @param documentId documentId, must contain at least the account
      * @return dataManager object.
      * @throws FileNotFoundException if documentId is bogus or the account does not exist.
      */

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -471,6 +471,9 @@ public class SeafileProvider extends DocumentsProvider {
             SeafRepo repo = dm.getCachedRepoByID(repoId);
 
             List<SeafDirent> list = dm.getDirentsFromServer(repoId, parentPath);
+            if (list == null) {
+                throw new SeafException(0, SeadroidApplication.getAppContext().getString(R.string.saf_write_diretory_exception));
+            }
 
             // first check if target already exist. if yes, abort
             for (SeafDirent e: list) {

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -251,7 +251,7 @@ public class SeafileProvider extends DocumentsProvider {
 
         Log.d(DEBUG_TAG, "queryDocument: " + documentId);
 
-        String[] netProjection = 
+        String[] netProjection =
                 netProjection(projection, SUPPORTED_DOCUMENT_PROJECTION);
         MatrixCursor result = new MatrixCursor(netProjection);
 
@@ -267,7 +267,7 @@ public class SeafileProvider extends DocumentsProvider {
 
         // the android API asks us to be quick, so just use the cache.
         SeafRepo repo = dm.getCachedRepoByID(repoId);
-        if (repo==null)
+        if (repo == null)
             throw new FileNotFoundException();
 
         String path = DocumentIdParser.getPathFromId(documentId);
@@ -475,14 +475,15 @@ public class SeafileProvider extends DocumentsProvider {
             // first check if target already exist. if yes, abort
             for (SeafDirent e: list) {
                 if (e.getTitle().equals(displayName)) {
-                    throw new SeafException(0, "File exists already");
+                    throw new SeafException(0, SeadroidApplication.getAppContext().getString(R.string.saf_file_exist));
                 }
             }
 
             if (repo == null || !repo.hasWritePermission()) {
-                throw new SeafException(0, "Repo not found or no write perms");
+                throw new SeafException(0, SeadroidApplication.getAppContext().getString(R.string.saf_write_diretory_exception));
             } else if (mimeType == null) {
-                throw new SeafException(0, "Bad mime type given by caller");
+                // bad mime type given by caller
+                throw new SeafException(0, SeadroidApplication.getAppContext().getString(R.string.saf_bad_mime_type));
             } else if (mimeType.equals(Document.MIME_TYPE_DIR)) {
                 dm.createNewDir(repoId, parentPath, displayName);
             } else {
@@ -769,7 +770,7 @@ public class SeafileProvider extends DocumentsProvider {
                     dm.getDirentsFromServer(repoId, path);
 
                 } catch (SeafException e) {
-                    Log.e(getClass().getSimpleName(), "Exception while querying server", e);
+                    Log.e(DEBUG_TAG, "Exception while querying server", e);
                 }
                 // notify the SAF to to do a new queryChildDocuments
                 getContext().getContentResolver().notifyChange(uri, null);
@@ -797,7 +798,7 @@ public class SeafileProvider extends DocumentsProvider {
                     dm.getStarredFiles();
 
                 } catch (SeafException e) {
-                    Log.e(getClass().getSimpleName(), "Exception while querying server", e);
+                    Log.e(DEBUG_TAG, "Exception while querying server", e);
                 }
                 // notify the SAF to to do a new queryChildDocuments
                 getContext().getContentResolver().notifyChange(uri, null);
@@ -826,7 +827,7 @@ public class SeafileProvider extends DocumentsProvider {
                     dm.getReposFromServer();
 
                 } catch (SeafException e) {
-                    Log.e(getClass().getSimpleName(), "Exception while querying server", e);
+                    Log.e(DEBUG_TAG, "Exception while querying server", e);
                 }
                 // notify the SAF to to do a new queryChildDocuments
                 getContext().getContentResolver().notifyChange(uri, null);

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -347,13 +347,15 @@ public class SeafileProvider extends DocumentsProvider {
             }
         });
 
-        signal.setOnCancelListener(new CancellationSignal.OnCancelListener() {
-            @Override
-            public void onCancel() {
-                Log.d(DEBUG_TAG, "openDocument cancelling download");
-                future.cancel(true);
-            }
-        });
+        if (signal != null) {
+            signal.setOnCancelListener(new CancellationSignal.OnCancelListener() {
+                @Override
+                public void onCancel() {
+                    Log.d(DEBUG_TAG, "openDocument cancelling download");
+                    future.cancel(true);
+                }
+            });
+        }
 
         try {
             return future.get();
@@ -423,13 +425,15 @@ public class SeafileProvider extends DocumentsProvider {
             }
         });
 
-        signal.setOnCancelListener(new CancellationSignal.OnCancelListener() {
-            @Override
-            public void onCancel() {
-                Log.d(DEBUG_TAG, "openDocumentThumbnail cancelling download");
-                future.cancel(true);
-            }
-        });
+        if (signal != null) {
+            signal.setOnCancelListener(new CancellationSignal.OnCancelListener() {
+                @Override
+                public void onCancel() {
+                    Log.d(DEBUG_TAG, "openDocumentThumbnail cancelling download");
+                    future.cancel(true);
+                }
+            });
+        }
 
         try {
             return future.get();

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -73,6 +73,7 @@ public class SeafileProvider extends DocumentsProvider {
             Root.COLUMN_FLAGS,
             Root.COLUMN_TITLE,
             Root.COLUMN_DOCUMENT_ID,
+            Root.COLUMN_SUMMARY,
             Root.COLUMN_ICON
     };
 
@@ -109,13 +110,7 @@ public class SeafileProvider extends DocumentsProvider {
 
         // add a Root for every Seafile account we have.
         for(Account a: AccountDBHelper.getDatabaseHelper(getContext()).getAccountList()) {
-            MatrixCursor.RowBuilder row = result.newRow();
-
-            row.add(Root.COLUMN_ROOT_ID, a.getServerHost());
-            row.add(Root.COLUMN_ICON, R.drawable.ic_launcher);
-            row.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_IS_CHILD);
-            row.add(Root.COLUMN_TITLE, a.getName());
-            row.add(Root.COLUMN_DOCUMENT_ID, a.getServer());
+            includeRoot(result, a);
         }
 
         // notification uri for the event, that the account list has changed
@@ -468,12 +463,13 @@ public class SeafileProvider extends DocumentsProvider {
         String docId = DocumentIdParser.buildId(account, null, null);
 
         final MatrixCursor.RowBuilder row = result.newRow();
-        row.add(Document.COLUMN_DOCUMENT_ID, docId);
-        row.add(Document.COLUMN_DISPLAY_NAME, account.getServerHost());
-        row.add(Document.COLUMN_SIZE, 0);
-        row.add(Document.COLUMN_MIME_TYPE, DocumentsContract.Document.MIME_TYPE_DIR);
-        row.add(Document.COLUMN_LAST_MODIFIED, 0);
-        row.add(Document.COLUMN_FLAGS, 0);
+
+        row.add(Root.COLUMN_ROOT_ID, docId);
+        row.add(Root.COLUMN_DOCUMENT_ID, docId);
+        row.add(Root.COLUMN_ICON, R.drawable.ic_launcher);
+        row.add(Root.COLUMN_FLAGS, Root.FLAG_SUPPORTS_IS_CHILD | Root.FLAG_SUPPORTS_CREATE);
+        row.add(Root.COLUMN_TITLE, account.getServerHost());
+        row.add(Root.COLUMN_SUMMARY, account.getEmail());
     }
 
     /**

--- a/src/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/src/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -208,10 +208,14 @@ public class SeafileProvider extends DocumentsProvider {
             // in this case, the repository is known. the user wants the entries of a specific
             // directory in the given repository.
 
-            String path = DocumentIdParser.getPathFromId(parentDocumentId);
+            SeafRepo repo = dm.getCachedRepoByID(repoId);
+
+            // encrypted repos are not supported (we can't ask the user for the passphrase)
+            if (repo.encrypted) {
+                throw new FileNotFoundException();
+            }
 
             MatrixCursor result;
-
 
             // fetch new dirents in the background
             if (!parentDocumentId.equals(lastQueriedDocumentId)) {


### PR DESCRIPTION
These are a couple of patches to the Seafile Document Provider.

I've split them into a patchset for easier reviewing. However each patch by itself will very likely not compile.

* Support writing (uploading) files
* Support creating files/directories
* Show starred files
* Improve repository list: use seafile icons for repositories, show descriptions
* fix: don't allow user to enter encrypted repos. that was previously broken.
* improve account (root) list: display account email adress in 2nd line
* use a thread pool for concurrent tasks (instead of spawning a new Thread each time)
* remove verbose FileNotFoundExceptions (with translated strings). they aren't shown to the user anyway.
* some refactoring
* some small fixes

#### Test Case
see [test case](https://github.com/haiwen/seadroid/wiki/Document-Provider:-write-support-test-case)

List of roots:
![roots](https://cloud.githubusercontent.com/assets/676900/6541894/cefb8c84-c4e7-11e4-866a-92af4a070877.png)

List of repositories:
![repos](https://cloud.githubusercontent.com/assets/676900/6541896/de6418ee-c4e7-11e4-9434-2d0d83b8f376.png)
