### PR TITLE
fix download folder not working bug

### DIFF
--- a/src/com/seafile/seadroid2/transfer/DownloadTaskManager.java
+++ b/src/com/seafile/seadroid2/transfer/DownloadTaskManager.java
@@ -69,8 +69,7 @@ public class DownloadTaskManager extends TransferManager implements DownloadStat
      * get all download task info under a specific directory.
      *
      * @param repoID
-     * @param dir    valid dir should be something like this "/DIRNAME/", instead of "/DIRNAME",
-     *               in order to ensure the param being consistent with its caller
+     * @param dir
      * @return List<DownloadTaskInfo>
      */
     public List<DownloadTaskInfo> getTaskInfoListByPath(String repoID, String dir) {
@@ -80,14 +79,8 @@ public class DownloadTaskManager extends TransferManager implements DownloadStat
                 continue;
 
             String parentDir = Utils.getParentPath(task.getPath());
-            String validDir;
 
-            if (!parentDir.equals("/"))
-                validDir = parentDir + "/";
-            else
-                validDir = parentDir;
-
-            if (validDir.equals(dir))
+            if (parentDir.equals(dir))
                 infos.add(((DownloadTask) task).getTaskInfo());
         }
 

--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -950,7 +950,7 @@ public class BrowserActivity extends SherlockFragmentActivity
         startFileActivity(repoName, repoID, filePath);
     }
 
-    public void downloadDir(String direntName) {
+    public void downloadDir(String dirPath) {
         if (!Utils.isNetworkOn()) {
             ToastUtils.show(this, R.string.network_down);
             return;
@@ -958,7 +958,7 @@ public class BrowserActivity extends SherlockFragmentActivity
 
         final String repoName = navContext.getRepoName();
         final String repoID = navContext.getRepoID();
-        ConcurrentAsyncTask.execute(new DownloadDirTask(), repoName, repoID, direntName);
+        ConcurrentAsyncTask.execute(new DownloadDirTask(), repoName, repoID, dirPath);
 
     }
 
@@ -966,7 +966,7 @@ public class BrowserActivity extends SherlockFragmentActivity
 
         private String repoName;
         private String repoID;
-        private String filePath;
+        private String dirPath;
         private int fileCount;
 
         SeafException err = null;
@@ -980,11 +980,11 @@ public class BrowserActivity extends SherlockFragmentActivity
 
             repoName = params[0];
             repoID = params[1];
-            filePath = params[2];
+            dirPath = params[2];
 
             List<SeafDirent> dirents;
             try {
-                dirents = dataManager.getDirentsFromServer(repoID, filePath);
+                dirents = dataManager.getDirentsFromServer(repoID, dirPath);
             } catch (SeafException e) {
                 err = e;
                 e.printStackTrace();
@@ -998,24 +998,24 @@ public class BrowserActivity extends SherlockFragmentActivity
                 if (!seafDirent.isDir()) {
                     File localCachedFile = dataManager.getLocalCachedFile(repoName, 
                                                                           repoID, 
-                                                                          Utils.pathJoin(filePath, 
+                                                                          Utils.pathJoin(dirPath,
                                                                                           seafDirent.name), 
                                                                           seafDirent.id);
                     if (localCachedFile != null) {
                         continue;
                     }
 
-                    // Log.d(DEBUG_TAG, Utils.pathJoin(repoName, filePath, seafDirent.name));
+                    // Log.d(DEBUG_TAG, Utils.pathJoin(repoName, dirPath, seafDirent.name));
                     txService.addTaskToDownloadQue(account,
                             repoName,
                             repoID,
-                            Utils.pathJoin(filePath,
+                            Utils.pathJoin(dirPath,
                                     seafDirent.name));
                 }
 
             }
 
-            fileCount = txService.getDownloadingFileCountByPath(repoID, filePath);
+            fileCount = txService.getDownloadingFileCountByPath(repoID, dirPath);
 
             return dirents;
 
@@ -1036,7 +1036,7 @@ public class BrowserActivity extends SherlockFragmentActivity
                 ToastUtils.show(BrowserActivity.this, getResources().getQuantityString(R.plurals.transfer_download_started, fileCount, fileCount));
 
             // set download tasks info to adapter in order to update download progress in UI thread
-            getReposFragment().getAdapter().setDownloadTaskList(txService.getDownloadTaskInfosByPath(repoID, filePath));
+            getReposFragment().getAdapter().setDownloadTaskList(txService.getDownloadTaskInfosByPath(repoID, dirPath));
         }
     }
 

--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -685,8 +685,7 @@ public class BrowserActivity extends SherlockFragmentActivity
             }
             return true;
         case R.id.download_folder:
-            String parentPath = Utils.getParentPath(navContext.getDirPath());
-            downloadDir(parentPath);
+            downloadDir(navContext.getDirPath());
             break;
         case R.id.newdir:
             showNewDirDialog();
@@ -959,9 +958,7 @@ public class BrowserActivity extends SherlockFragmentActivity
 
         final String repoName = navContext.getRepoName();
         final String repoID = navContext.getRepoID();
-        final String filePath = Utils.pathJoin(navContext.getDirPath(), direntName);
-        ConcurrentAsyncTask.execute(new DownloadDirTask(), repoName, repoID, filePath);
-        // Log.d(DEBUG_TAG, "download >> " + repoName + navContext.getDirPath());
+        ConcurrentAsyncTask.execute(new DownloadDirTask(), repoName, repoID, direntName);
 
     }
 
@@ -1027,8 +1024,9 @@ public class BrowserActivity extends SherlockFragmentActivity
         @Override
         protected void onPostExecute(List<SeafDirent> dirents) {
             if (dirents == null) {
-                if (err != null)
+                if (err != null) {
                     ToastUtils.show(BrowserActivity.this, R.string.transfer_list_network_error);
+                }
                 return;
             }
 


### PR DESCRIPTION
#### Reported by 
Download folder feature does not work #290

#### Steps to reproduce the bug
* login Seafile account
* navigate into repo like "Seafile-design"
* navigate into subfolders like "/new-design/seahub/v5.0"
* click overflow menu and choose "Download folder"
* toast the message "Network connection error, please try again later!", which failed downloading the folder

#### Causes
the requested path parameter is incorrect.

WRONG
dirPath: `/new-design/seahub/v5.0`
direntName:`/new-design/seahub`
assembled requested path:`/new-design/seahub/v5.0/new-design/seahub` (not exist)

RIGHT
dirPath: `/new-design/seahub/v5.0`
direntName:`v5.0`
assembled requested path:`/new-design/seahub/v5.0`


