### PR TITLE
Fix concurrent exceptions

### DIFF
--- a/src/com/seafile/seadroid2/transfer/TransferManager.java
+++ b/src/com/seafile/seadroid2/transfer/TransferManager.java
@@ -28,15 +28,15 @@ public abstract class TransferManager {
     /**
      * contains all transfer tasks, including failed, cancelled, finished, transferring, waiting tasks.
      */
-    protected List<TransferTask> allTaskList = new CopyOnWriteArrayList();
+    protected List<TransferTask> allTaskList = Lists.newArrayList();
     /**
      * contains currently transferring tasks
      */
-    protected List<TransferTask> transferringList = new CopyOnWriteArrayList();
+    protected List<TransferTask> transferringList = Lists.newArrayList();
     /**
      * contains waiting tasks
      */
-    protected List<TransferTask> waitingList = new CopyOnWriteArrayList();
+    protected List<TransferTask> waitingList = Lists.newArrayList();
 
     protected TransferTask getTask(int taskID) {
         for (TransferTask task : allTaskList) {


### PR DESCRIPTION
CopyOnWriteArrayList has several downsides
* crash when removing items caused by UnsupportedOperationException 
* updating (e.g. add or set) this collection a lot will [kill performance](http://stackoverflow.com/a/17853225/3962551)

crash log
```
java.lang.UnsupportedOperationException
E/AndroidRuntime(19137): 	at java.util.concurrent.CopyOnWriteArrayList$CowIterator.remove(CopyOnWriteArrayList.java:744)
E/AndroidRuntime(19137): 	at com.seafile.seadroid2.transfer.TransferManager.removeByState(TransferManager.java:135)
E/AndroidRuntime(19137): 	at com.seafile.seadroid2.transfer.TransferService.removeAllUploadTasksByState(TransferService.java:80)
E/AndroidRuntime(19137): 	at com.seafile.seadroid2.ui.fragment.UploadTaskFragment.onContextItemSelected(UploadTaskFragment.java:79)
```
To solve this by surrounding the code that try to modify this list in a synchronized block with some lock so that the thread trying to modify the ArrayList wait for the iterator to complete (avoid array list ConcurrentModificationException).