### PR TITLE
fix: error when uploading same file again

### DIFF
--- a/src/com/seafile/seadroid2/data/DataManager.java
+++ b/src/com/seafile/seadroid2/data/DataManager.java
@@ -494,6 +494,9 @@ public class DataManager {
     }
 
     public void addCachedFile(String repoName, String repoID, String path, String fileID, File file) {
+        // notify Android Gallery that a new file has appeared
+        Utils.notifyAndroidGalleryFileChange(file);
+
         SeafCachedFile item = new SeafCachedFile();
         item.repoName = repoName;
         item.repoID = repoID;

--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -1046,11 +1046,7 @@ public class BrowserActivity extends SherlockFragmentActivity
                 OutputStream out = null;
 
                 try {
-                    if (!tempDir.exists()) {
-                        if (!tempDir.mkdirs()) {
-                            throw new RuntimeException(getString(R.string.saf_failed_to_create_directory, tempDir.getAbsolutePath()));
-                        }
-                    }
+                    tempDir.mkdirs();
 
                     if (!tempFile.createNewFile()) {
                         throw new RuntimeException("could not create temporary file");

--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -1037,7 +1037,7 @@ public class BrowserActivity extends SherlockFragmentActivity
 
             List<File> fileList = new ArrayList<File>();
             for (Uri uri: uriList) {
-                File tempDir = new File(DataManager.getExternalTempDirectory(), "saf_temp");
+                File tempDir = new File(DataManager.getExternalTempDirectory(), "saf_temp" + "/" + "upload-"+System.currentTimeMillis());
                 File tempFile = new File(tempDir, Utils.getFilenamefromUri(BrowserActivity.this, uri));
 
                 Log.d(DEBUG_TAG, "Uploading file from uri: " + uri);
@@ -1047,7 +1047,7 @@ public class BrowserActivity extends SherlockFragmentActivity
 
                 try {
                     if (!tempDir.exists()) {
-                        if (!tempDir.mkdir()) {
+                        if (!tempDir.mkdirs()) {
                             throw new RuntimeException(getString(R.string.saf_failed_to_create_directory, tempDir.getAbsolutePath()));
                         }
                     }

--- a/src/com/seafile/seadroid2/util/Utils.java
+++ b/src/com/seafile/seadroid2/util/Utils.java
@@ -615,6 +615,13 @@ public class Utils {
         fileOrDirectory.renameTo(renamedFile);
         renamedFile.delete();
 
+        // notify Android Gallery that this file is gone
+        notifyAndroidGalleryFileChange(fileOrDirectory);
+    }
+
+    public static void notifyAndroidGalleryFileChange(File file) {
+        Intent intent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, Uri.fromFile(file));
+        SeadroidApplication.getAppContext().sendBroadcast(intent);
     }
 
     /**


### PR DESCRIPTION
Reasoning: Temp files aren't deleted after upload.
If the user tries to upload the same file twice,
the temp file cannot be created again, causing an

    throw new RuntimeException("could not create temporary file");

We can't delete or overwrite the existing temp file, as the upload
might still be in progress.

There are other ways to fix this issue, but this is the simplest solution,
as far as I can see.