### PR TITLE
instruct android gallery to ignore files locally cached by seafile

### DIFF
--- a/src/com/seafile/seadroid2/data/DataManager.java
+++ b/src/com/seafile/seadroid2/data/DataManager.java
@@ -60,9 +60,26 @@ public class DataManager {
             if (!extDir.exists()) {
                 extDir.mkdirs();
             }
+            createMediaIgnoreFile(extDir);
             return extDir.getAbsolutePath();
         } else {
             throw new RuntimeException("External Storage is currently not available");
+        }
+    }
+
+    /**
+     * Tell the Android Gallery to ignore these directories
+     *
+     * @param extDir
+     */
+    private static void createMediaIgnoreFile(File extDir) {
+        File extDirnomedia = new File(extDir, ".nomedia");
+        if (!extDirnomedia.exists()) {
+            try {
+                extDirnomedia.createNewFile();
+            } catch (IOException e) {
+                throw new RuntimeException("Could not create marker file ", e);
+            }
         }
     }
 


### PR DESCRIPTION
this affects

- the Android Gallery
- the ACTION_GET_CONTENT image picker

Both will crawl the seafile internal directories from time to time
and include the containing images into the gallery. I think this is
confusing. The gallery will only show the small subset of cached images,
which is not very useful and potentially confusing to users.

Also the way Seafile currently purges its cache, the Android gallery won't
get notified if images are deleted(*). This results in stale entries in the
image gallery of files. The files are listed (sometimes with thumbnails,
sometimes not). But trying to open them will result in an error.

(*) This could be fixed, however, in other ways.