### PR TITLE
Catch external storage not available exceptions

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="library_read_only">This library is read-only</string>
     <string name="error_when_load_dirents">Error when loading the folder</string>
     <string name="error_when_load_repos">Error when loading libraries</string>
+    <string name="error_when_write_external_storage">External Storage is currently not available</string>
     <string name="dir_empty">This folder is empty</string>
     <string name="no_repo">You have no libraries yet</string>
     <string name="no_app_available">No app can be found</string>

--- a/src/com/seafile/seadroid2/SeadroidApplication.java
+++ b/src/com/seafile/seadroid2/SeadroidApplication.java
@@ -5,6 +5,7 @@ import java.io.File;
 import android.app.Application;
 import android.content.Context;
 
+import android.util.Log;
 import com.nostra13.universalimageloader.cache.disc.impl.UnlimitedDiscCache;
 import com.nostra13.universalimageloader.cache.disc.naming.Md5FileNameGenerator;
 import com.nostra13.universalimageloader.core.ImageLoader;
@@ -15,6 +16,8 @@ import com.seafile.seadroid2.data.DataManager;
 import com.seafile.seadroid2.gesturelock.AppLockManager;
 
 public class SeadroidApplication extends Application {
+    public static final String DEBUG_TAG = "SeadroidApplication";
+
     private static Context context;
     
     public void onCreate() {
@@ -31,8 +34,13 @@ public class SeadroidApplication extends Application {
     }
     
     public static void initImageLoader(Context context) {
-        
-        File cacheDir = DataManager.getThumbnailCacheDirectory();
+
+        File cacheDir = null;
+        try {
+            cacheDir = DataManager.getThumbnailCacheDirectory();
+        } catch (SeafException e) {
+            Log.e(DEBUG_TAG, "error message " + e.getMessage() + " error code " + e.getCode());
+        }
         // This configuration tuning is custom. You can tune every option, you may tune some of them,
         // or you can create default configuration by
         //  ImageLoaderConfiguration.createDefault(this);

--- a/src/com/seafile/seadroid2/SeadroidApplication.java
+++ b/src/com/seafile/seadroid2/SeadroidApplication.java
@@ -40,6 +40,7 @@ public class SeadroidApplication extends Application {
             cacheDir = DataManager.getThumbnailCacheDirectory();
         } catch (SeafException e) {
             Log.e(DEBUG_TAG, "error message " + e.getMessage() + " error code " + e.getCode());
+            return;
         }
         // This configuration tuning is custom. You can tune every option, you may tune some of them,
         // or you can create default configuration by

--- a/src/com/seafile/seadroid2/SeafException.java
+++ b/src/com/seafile/seadroid2/SeafException.java
@@ -15,6 +15,7 @@ public class SeafException extends Exception {
     public static final SeafException illFormatException = new SeafException(4, "Ill-formatted Response");
     public static final SeafException sslException = new SeafException(5, "not trusted SSL server");
     public static final SeafException userCancelledException = new SeafException(6, "operation canclled by user");
+    public static final SeafException externalStorageUnavailableException = new SeafException(7, "External Storage Unavailable");
 
     public SeafException(int code, String msg) {
         super(msg);

--- a/src/com/seafile/seadroid2/data/DataManager.java
+++ b/src/com/seafile/seadroid2/data/DataManager.java
@@ -358,7 +358,7 @@ public class DataManager {
         } catch (SeafException e) {
             Log.e(DEBUG_TAG, "error message " + e.getMessage() + " error code " + e.getCode());
         }
-        if (cache.exists()) {
+        if (cache != null && cache.exists()) {
             String json = Utils.readFile(cache);
             reposCache = parseRepos(json);
             return reposCache;

--- a/src/com/seafile/seadroid2/data/DataManager.java
+++ b/src/com/seafile/seadroid2/data/DataManager.java
@@ -86,19 +86,19 @@ public class DataManager {
         }
     }
 
-    public static String getExternalTempDirectory() {
+    public static String getExternalTempDirectory() throws SeafException {
         String root = getExternalRootDirectory();
         File tmpDir = new File(root + "/" + "temp");
         return getDirectoryCreateIfNeeded(tmpDir);
     }
 
-    public static String getThumbDirectory() {
+    public static String getThumbDirectory() throws SeafException {
         String root = SeadroidApplication.getAppContext().getCacheDir().getAbsolutePath();
         File tmpDir = new File(root + "/" + "thumb");
         return getDirectoryCreateIfNeeded(tmpDir);
     }
 
-    public static String getExternalCacheDirectory() {
+    public static String getExternalCacheDirectory() throws SeafException {
         String root = getExternalRootDirectory();
         File tmpDir = new File(root + "/" + "cache");
         return getDirectoryCreateIfNeeded(tmpDir);
@@ -134,17 +134,17 @@ public class DataManager {
         return new File(p);
     }
 
-    public static File getTempFile(String path, String oid) {
+    public static File getTempFile(String path, String oid) throws SeafException {
         String p = getExternalTempDirectory() + "/" + constructFileName(path, oid);
         return new File(p);
     }
 
     // Obtain a cache file for storing a directory with oid
-    public static File getFileForDirentsCache(String oid) {
+    public static File getFileForDirentsCache(String oid) throws SeafException {
         return new File(getExternalCacheDirectory() + "/" + oid);
     }
     
-    public static File getThumbnailCacheDirectory() {
+    public static File getThumbnailCacheDirectory() throws SeafException {
         return new File(getExternalCacheDirectory() + "/thumbnails");
     }
 
@@ -190,7 +190,7 @@ public class DataManager {
         return account;
     }
 
-    private File getFileForReposCache() {
+    private File getFileForReposCache() throws SeafException {
         String filename = "repos-" + (account.server + account.email).hashCode() + ".dat";
         return new File(getExternalCacheDirectory() + "/" + filename);
     }
@@ -332,7 +332,9 @@ public class DataManager {
     }
 
     public SeafRepo getCachedRepoByID(String id) {
-        List<SeafRepo> cachedRepos = getReposFromCache();
+        List<SeafRepo> cachedRepos = null;
+        cachedRepos = getReposFromCache();
+
         if (cachedRepos == null) {
             return null;
         }
@@ -350,7 +352,12 @@ public class DataManager {
         if (reposCache != null)
             return reposCache;
 
-        File cache = getFileForReposCache();
+        File cache = null;
+        try {
+            cache = getFileForReposCache();
+        } catch (SeafException e) {
+            Log.e(DEBUG_TAG, "error message " + e.getMessage() + " error code " + e.getCode());
+        }
         if (cache.exists()) {
             String json = Utils.readFile(cache);
             reposCache = parseRepos(json);

--- a/src/com/seafile/seadroid2/data/DataManager.java
+++ b/src/com/seafile/seadroid2/data/DataManager.java
@@ -54,6 +54,26 @@ public class DataManager {
         dbHelper = DatabaseHelper.getDatabaseHelper();
     }
 
+
+    /** Checks if external storage is available for read and write */
+    public static boolean isExternalStorageWritable() {
+        String state = Environment.getExternalStorageState();
+        if (Environment.MEDIA_MOUNTED.equals(state)) {
+            return true;
+        }
+        return false;
+    }
+
+    /** Checks if external storage is available to at least read */
+    public static boolean isExternalStorageReadable() {
+        String state = Environment.getExternalStorageState();
+        if (Environment.MEDIA_MOUNTED.equals(state) ||
+                Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
+            return true;
+        }
+        return false;
+    }
+
     public static String getExternalRootDirectory() {
         if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
             File extDir = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/Seafile/");
@@ -84,11 +104,16 @@ public class DataManager {
         return getDirectoryCreateIfNeeded(tmpDir);
     }
 
-    private static String getDirectoryCreateIfNeeded(File dir) {
+    private static String getDirectoryCreateIfNeeded(File dir) throws SeafException {
         if (dir.exists()) {
             return dir.getAbsolutePath();
         } else {
-            dir.mkdirs();
+            if (isExternalStorageWritable())
+                dir.mkdirs();
+            else {
+                Log.e(DEBUG_TAG, "External Storage is currently not available");
+                throw SeafException.externalStorageUnavailableException;
+            }
         }
         return dir.getAbsolutePath();
     }

--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -1044,7 +1044,12 @@ public class BrowserActivity extends SherlockFragmentActivity
 
             List<File> fileList = new ArrayList<File>();
             for (Uri uri: uriList) {
-                File tempDir = new File(DataManager.getExternalTempDirectory(), "saf_temp" + "/" + "upload-"+System.currentTimeMillis());
+                File tempDir = null;
+                try {
+                    tempDir = new File(DataManager.getExternalTempDirectory(), "saf_temp" + "/" + "upload-"+System.currentTimeMillis());
+                } catch (SeafException e) {
+                    Log.e(DEBUG_TAG, "error message " + e.getMessage() + " error code " + e.getCode());
+                }
                 File tempFile = new File(tempDir, Utils.getFilenamefromUri(BrowserActivity.this, uri));
 
                 Log.d(DEBUG_TAG, "Uploading file from uri: " + uri);

--- a/src/com/seafile/seadroid2/ui/activity/SearchActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/SearchActivity.java
@@ -272,7 +272,13 @@ public class SearchActivity extends SherlockFragmentActivity implements View.OnC
         @Override
         public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
             final SearchedFile searchedFile = (SearchedFile) mAdapter.getItem(position);
-            onSearchedFileSelected(searchedFile);
+            try {
+                onSearchedFileSelected(searchedFile);
+            } catch (SeafException e) {
+                Log.e(DEBUG_TAG, "error message " + e.getMessage() + " error code " + e.getCode());
+                if (e.getCode() == 7)
+                    ToastUtils.show(SearchActivity.this, getString(R.string.error_when_write_external_storage));
+            }
         }
     }
 
@@ -312,7 +318,7 @@ public class SearchActivity extends SherlockFragmentActivity implements View.OnC
         }
     }
 
-    public void onSearchedFileSelected(SearchedFile searchedFile) {
+    public void onSearchedFileSelected(SearchedFile searchedFile) throws SeafException {
         final String repoID = searchedFile.getRepoID();
         SeafRepo seafRepo = dataManager.getCachedRepoByID(repoID);
         final String repoName = seafRepo.getName();

--- a/src/com/seafile/seadroid2/ui/adapter/SearchAdapter.java
+++ b/src/com/seafile/seadroid2/ui/adapter/SearchAdapter.java
@@ -1,5 +1,6 @@
 package com.seafile.seadroid2.ui.adapter;
 
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -8,6 +9,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import com.google.common.collect.Lists;
 import com.seafile.seadroid2.R;
+import com.seafile.seadroid2.SeafException;
 import com.seafile.seadroid2.data.SeafRepo;
 import com.seafile.seadroid2.data.SearchedFile;
 import com.seafile.seadroid2.ui.activity.SearchActivity;
@@ -20,6 +22,7 @@ import java.util.List;
  *
  */
 public class SearchAdapter extends BaseAdapter {
+    public static final String DEBUG_TAG = "SearchAdapter";
 
     private List<SearchedFile> items;
     private SearchActivity mActivity;

--- a/src/com/seafile/seadroid2/ui/fragment/SettingsPreferenceFragment.java
+++ b/src/com/seafile/seadroid2/ui/fragment/SettingsPreferenceFragment.java
@@ -189,7 +189,11 @@ public class SettingsPreferenceFragment extends CustomPreferenceFragment impleme
         authorInfo.setOnPreferenceClickListener(this);
         // Cache
         cacheSizePrf = findPreference(SettingsManager.SETTINGS_CACHE_SIZE_KEY);
-        calculateCacheSize();
+        try {
+            calculateCacheSize();
+        } catch (SeafException e) {
+            Log.e(DEBUG_TAG, "error message " + e.getMessage() + " error code " + e.getCode());
+        }
 
         // Clear cache
         clearCache = findPreference(SettingsManager.SETTINGS_CLEAR_CACHE_KEY);
@@ -296,12 +300,16 @@ public class SettingsPreferenceFragment extends CustomPreferenceFragment impleme
             builder.setMessage(Html.fromHtml(getString(R.string.settings_about_author_info, versionName)));
             builder.show();
         } else if (preference.getKey().equals(SettingsManager.SETTINGS_CLEAR_CACHE_KEY)) {
-            clearCache();
+            try {
+                clearCache();
+            } catch (SeafException e) {
+                Log.e(DEBUG_TAG, "error message " + e.getMessage() + " error code " + e.getCode());
+            }
         }
         return true;
     }
 
-    private void clearCache() {
+    private void clearCache() throws SeafException {
         String filesDir = dataMgr.getAccountDir();
         String cacheDir = DataManager.getExternalCacheDirectory();
         String tempDir = DataManager.getExternalTempDirectory();
@@ -485,7 +493,7 @@ public class SettingsPreferenceFragment extends CustomPreferenceFragment impleme
             return null;
     }
 
-    private void calculateCacheSize() {
+    private void calculateCacheSize() throws SeafException {
         String filesDir = dataMgr.getAccountDir();
         String cacheDir = DataManager.getExternalCacheDirectory();
         String tempDir = DataManager.getExternalTempDirectory();


### PR DESCRIPTION
catch exceptions instead of leaving the App crash.

error log reported by Google Play Console
```
java.lang.RuntimeException: Unable to create application com.seafile.seadroid2.SeadroidApplication: java.lang.RuntimeException: External Storage is currently not available
at android.app.ActivityThread.handleBindApplication(ActivityThread.java:4602)
at android.app.ActivityThread.access$1300(ActivityThread.java:142)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1324)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:156)
at android.app.ActivityThread.main(ActivityThread.java:5099)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:511)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:784)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:551)
at dalvik.system.NativeStart.main(Native Method)
Caused by: java.lang.RuntimeException: External Storage is currently not available
at com.seafile.seadroid2.data.DataManager.getExternalRootDirectory(DataManager.java:73)
at com.seafile.seadroid2.data.DataManager.getExternalCacheDirectory(DataManager.java:90)
at com.seafile.seadroid2.data.DataManager.getAvatarCacheDirectory(DataManager.java:136)
at com.seafile.seadroid2.SeadroidApplication.initImageLoader(SeadroidApplication.java:35)
at com.seafile.seadroid2.SeadroidApplication.onCreate(SeadroidApplication.java:23)
at android.app.Instrumentation.callApplicationOnCreate(Instrumentation.java:981)
at android.app.ActivityThread.handleBindApplication(ActivityThread.java:4599)
```