### PR TITLE
fix app crash when onFileUploadFailed was called

### DIFF
--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -1625,7 +1625,8 @@ public class BrowserActivity extends SherlockFragmentActivity
             return;
         }
         UploadTaskInfo info = txService.getUploadTaskInfo(taskID);
-        ToastUtils.show(this, getString(R.string.upload_failed) + " " + Utils.fileNameFromPath(info.localFilePath));
+        if (info != null)
+            ToastUtils.show(this, getString(R.string.upload_failed) + " " + Utils.fileNameFromPath(info.localFilePath));
     }
 
     public PasswordDialog showPasswordDialog(String repoName, String repoID,


### PR DESCRIPTION
error log

```
java.lang.NullPointerException
at com.seafile.seadroid2.ui.activity.BrowserActivity.onFileUploadFailed(BrowserActivity.java:1467)
at com.seafile.seadroid2.ui.activity.BrowserActivity.access$1000(BrowserActivity.java:86)
at com.seafile.seadroid2.ui.activity.BrowserActivity$TransferReceiver.onReceive(BrowserActivity.java:1514)
at android.support.v4.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:297)
at android.support.v4.content.LocalBroadcastManager.access$000(LocalBroadcastManager.java:46)
at android.support.v4.content.LocalBroadcastManager$1.handleMessage(LocalBroadcastManager.java:116)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loop(Looper.java:146)
at android.app.ActivityThread.main(ActivityThread.java:5511)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:515)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1283)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1099)
at dalvik.system.NativeStart.main(Native Method)
```