### PR TITLE
fix SeafileMonitor removeObserver NPE

### DIFF
--- a/src/com/seafile/seadroid2/monitor/SeafileMonitor.java
+++ b/src/com/seafile/seadroid2/monitor/SeafileMonitor.java
@@ -39,7 +39,9 @@ public class SeafileMonitor {
 
     public synchronized void stopMonitorFilesForAccount(Account account) {
         SeafileObserver fileObserver = observers.get(account);
-        removeObserver(fileObserver);
+        if (fileObserver != null)
+            removeObserver(fileObserver);
+
         observers.remove(account);
     }
 


### PR DESCRIPTION
crash log 
```
java.lang.NullPointerException
at com.seafile.seadroid2.monitor.SeafileMonitor.removeObserver(SeafileMonitor.java:51)
at com.seafile.seadroid2.monitor.SeafileMonitor.stopMonitorFilesForAccount(SeafileMonitor.java:42)
at com.seafile.seadroid2.monitor.FileMonitorService.removeAccount(FileMonitorService.java:97)
at com.seafile.seadroid2.ui.activity.AccountsActivity.onContextItemSelected(AccountsActivity.java:213)
at android.app.Activity.onMenuItemSelected(Activity.java:2620)
at android.support.v4.app.FragmentActivity.onMenuItemSelected(FragmentActivity.java:361)
at com.actionbarsherlock.app.SherlockFragmentActivity.onMenuItemSelected(SherlockFragmentActivity.java:210)
at com.android.internal.policy.impl.PhoneWindow$DialogMenuCallback.onMenuItemSelected(PhoneWindow.java:4129)
at com.android.internal.view.menu.MenuBuilder.dispatchMenuItemSelected(MenuBuilder.java:741)
at com.android.internal.view.menu.MenuItemImpl.invoke(MenuItemImpl.java:152)
at com.android.internal.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:884)
at com.android.internal.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:874)
at com.android.internal.view.menu.MenuDialogHelper.onClick(MenuDialogHelper.java:167)
at com.android.internal.app.AlertController$AlertParams$3.onItemClick(AlertController.java:941)
```