### PR TITLE
keep camera upload service running in background

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -385,7 +385,7 @@
     <!-- notification bar -->
     <string name="notification_upload_started_title">Uploading files&#8230;</string>
     <string name="notification_download_started_title">Downloading files&#8230;</string>
-    <string name="notification_upload_completed">Upload completed</string>
+    <string name="notification_upload_completed">Upload finished</string>
     <plurals name="notification_upload_info">
         <item quantity="one">Uploading <xliff:g id="uploading_file">%1$d</xliff:g> file (%2$d%%)</item>
         <item quantity="other">Uploading <xliff:g id="uploading_file">%1$d</xliff:g> files (%2$d%%)</item>
@@ -394,6 +394,9 @@
         <item quantity="one">Downloading <xliff:g id="downloading_file">%1$d</xliff:g> file (%2$d%%)</item>
         <item quantity="other">Downloading <xliff:g id="downloading_file">%1$d</xliff:g> files (%2$d%%)</item>
     </plurals>
-    <string name="notification_download_completed">Download completed</string>
+    <string name="notification_download_completed">Download finished</string>
+    <string name="notification_camera_upload_title">Upload photos&#8230;</string>
+    <string name="notification_camera_Upload_info">It may take a while</string>
+    <string name="notification_camera_upload_completed">Upload photos finished</string>
 
 </resources>

--- a/src/com/seafile/seadroid2/notification/BaseNotificationProvider.java
+++ b/src/com/seafile/seadroid2/notification/BaseNotificationProvider.java
@@ -31,7 +31,8 @@ public abstract class BaseNotificationProvider {
     public static final String NOTIFICATION_OPEN_UPLOAD_TAB = "open upload tab notification";
 
     public static final int NOTIFICATION_ID_DOWNLOAD = 1;
-    public static final int NOTIFICATION_ID_UPLOAD = 2;
+    public static final int NOTIFICATION_ID_NORMAR_UPLOAD = 2;
+    public static final int NOTIFICATION_ID_CAMERA_UPLOAD = 3;
 
     protected TransferManager txMgr;
     protected TransferService txService;

--- a/src/com/seafile/seadroid2/notification/CameraUploadNotificationProvider.java
+++ b/src/com/seafile/seadroid2/notification/CameraUploadNotificationProvider.java
@@ -1,0 +1,140 @@
+package com.seafile.seadroid2.notification;
+
+import android.app.PendingIntent;
+import android.content.Intent;
+import com.seafile.seadroid2.R;
+import com.seafile.seadroid2.SeadroidApplication;
+import com.seafile.seadroid2.transfer.*;
+import com.seafile.seadroid2.ui.activity.TransferActivity;
+
+import java.util.List;
+
+/**
+ * Camera upload notification provider
+ */
+public class CameraUploadNotificationProvider extends BaseNotificationProvider {
+
+    public CameraUploadNotificationProvider(TransferManager transferManager, TransferService transferService) {
+        super(transferManager, transferService);
+    }
+
+    @Override
+    protected NotificationState getState() {
+        if (txService == null)
+            return NotificationState.NOTIFICATION_STATE_COMPLETED;
+
+        List<UploadTaskInfo> infos = txService.getAllUploadTaskInfos();
+
+        int progressCount = 0;
+        int errorCount = 0;
+
+        for (UploadTaskInfo info : infos) {
+            if (info == null
+                    || info.isCopyToLocal)
+                continue;
+
+            if (info.state.equals(TaskState.INIT)
+                    || info.state.equals(TaskState.TRANSFERRING))
+                progressCount++;
+            else if (info.state.equals(TaskState.FAILED)
+                    || info.state.equals(TaskState.CANCELLED))
+                errorCount++;
+        }
+
+        if (progressCount == 0 && errorCount == 0)
+            return NotificationState.NOTIFICATION_STATE_COMPLETED;
+        else if (progressCount == 0 && errorCount > 0)
+            return NotificationState.NOTIFICATION_STATE_COMPLETED_WITH_ERRORS;
+        else // progressCount > 0
+            return NotificationState.NOTIFICATION_STATE_PROGRESS;
+    }
+
+    @Override
+    protected int getNotificationID() {
+        return NOTIFICATION_ID_CAMERA_UPLOAD;
+    }
+
+    @Override
+    protected String getNotificationTitle() {
+        return SeadroidApplication.getAppContext().getString(R.string.notification_camera_upload_title);
+    }
+
+    @Override
+    protected void notifyStarted() {
+        Intent uIntent = new Intent(SeadroidApplication.getAppContext(), TransferActivity.class);
+        uIntent.putExtra(NOTIFICATION_MESSAGE_KEY, NOTIFICATION_OPEN_UPLOAD_TAB);
+        uIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+
+        PendingIntent uPendingIntent = PendingIntent.getActivity(SeadroidApplication.getAppContext(),
+                (int) System.currentTimeMillis(),
+                uIntent,
+                0);
+        mNotifBuilder = CustomNotificationBuilder.getNotificationBuilder(SeadroidApplication.getAppContext())
+                .setSmallIcon(R.drawable.icon)
+                .setContentTitle(SeadroidApplication.getAppContext().getString(R.string.notification_camera_upload_title))
+                .setOngoing(true)
+                .setContentText(SeadroidApplication.getAppContext().getString(R.string.notification_camera_upload_title))
+                .setContentIntent(uPendingIntent)
+                .setProgress(100, 0, false);
+
+        // Make this service run in the foreground, supplying the ongoing
+        // notification to be shown to the user while in this state.
+        txService.startForeground(NOTIFICATION_ID_CAMERA_UPLOAD, mNotifBuilder.build());
+    }
+
+    @Override
+    protected String getProgressInfo() {
+        String progressStatus = "";
+
+        if (txService == null)
+            return progressStatus;
+
+        // failed or cancelled tasks won`t be shown in notification state
+        // but failed or cancelled detailed info can be viewed in TransferList
+        if (getState().equals(NotificationState.NOTIFICATION_STATE_COMPLETED_WITH_ERRORS))
+            progressStatus = SeadroidApplication.getAppContext().getString(R.string.notification_camera_upload_completed);
+        else if (getState().equals(NotificationState.NOTIFICATION_STATE_COMPLETED))
+            progressStatus = SeadroidApplication.getAppContext().getString(R.string.notification_camera_upload_completed);
+        else if (getState().equals(NotificationState.NOTIFICATION_STATE_PROGRESS)) {
+            int uploadingCount = 0;
+            List<UploadTaskInfo> infos = txService.getAllUploadTaskInfos();
+            for (UploadTaskInfo info : infos) {
+                if (info.isCopyToLocal)
+                    continue;
+                if (info.state.equals(TaskState.INIT)
+                        || info.state.equals(TaskState.TRANSFERRING))
+                    uploadingCount++;
+            }
+
+            if (uploadingCount != 0)
+                progressStatus = SeadroidApplication.getAppContext().getResources().
+                        getQuantityString(R.plurals.notification_upload_info,
+                                uploadingCount,
+                                uploadingCount,
+                                getProgress());
+        }
+        return progressStatus;
+    }
+
+    @Override
+    protected int getProgress() {
+        long uploadedSize = 0l;
+        long totalSize = 0l;
+        if (txService == null)
+            return 0;
+
+        List<UploadTaskInfo> infos = txService.getAllUploadTaskInfos();
+        for (UploadTaskInfo info : infos) {
+            if (info == null
+                    || info.isCopyToLocal)
+                continue;
+            uploadedSize += info.uploadedSize;
+            totalSize += info.totalSize;
+        }
+
+        if (totalSize == 0)
+            return 0;
+
+        return (int) (uploadedSize * 100 / totalSize);
+    }
+}

--- a/src/com/seafile/seadroid2/notification/CustomNotificationBuilder.java
+++ b/src/com/seafile/seadroid2/notification/CustomNotificationBuilder.java
@@ -1,4 +1,4 @@
-package com.seafile.seadroid2.ui;
+package com.seafile.seadroid2.notification;
 
 import android.app.Notification;
 import android.content.Context;

--- a/src/com/seafile/seadroid2/notification/DownloadNotificationProvider.java
+++ b/src/com/seafile/seadroid2/notification/DownloadNotificationProvider.java
@@ -8,7 +8,6 @@ import com.seafile.seadroid2.transfer.DownloadTaskInfo;
 import com.seafile.seadroid2.transfer.DownloadTaskManager;
 import com.seafile.seadroid2.transfer.TaskState;
 import com.seafile.seadroid2.transfer.TransferService;
-import com.seafile.seadroid2.ui.CustomNotificationBuilder;
 import com.seafile.seadroid2.ui.activity.TransferActivity;
 
 import java.util.List;

--- a/src/com/seafile/seadroid2/notification/UploadNotificationProvider.java
+++ b/src/com/seafile/seadroid2/notification/UploadNotificationProvider.java
@@ -8,7 +8,6 @@ import com.seafile.seadroid2.transfer.TaskState;
 import com.seafile.seadroid2.transfer.TransferService;
 import com.seafile.seadroid2.transfer.UploadTaskInfo;
 import com.seafile.seadroid2.transfer.UploadTaskManager;
-import com.seafile.seadroid2.ui.CustomNotificationBuilder;
 import com.seafile.seadroid2.ui.activity.TransferActivity;
 
 import java.util.List;
@@ -59,13 +58,13 @@ public class UploadNotificationProvider extends BaseNotificationProvider {
 
     @Override
     protected void notifyStarted() {
-        Intent dIntent = new Intent(SeadroidApplication.getAppContext(), TransferActivity.class);
-        dIntent.putExtra(NOTIFICATION_MESSAGE_KEY, NOTIFICATION_OPEN_UPLOAD_TAB);
-        dIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        Intent uIntent = new Intent(SeadroidApplication.getAppContext(), TransferActivity.class);
+        uIntent.putExtra(NOTIFICATION_MESSAGE_KEY, NOTIFICATION_OPEN_UPLOAD_TAB);
+        uIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 
         PendingIntent uPendingIntent = PendingIntent.getActivity(SeadroidApplication.getAppContext(),
                 (int) System.currentTimeMillis(),
-                dIntent,
+                uIntent,
                 0);
         mNotifBuilder = CustomNotificationBuilder.getNotificationBuilder(SeadroidApplication.getAppContext())
                 .setSmallIcon(R.drawable.icon)
@@ -77,7 +76,7 @@ public class UploadNotificationProvider extends BaseNotificationProvider {
 
         // Make this service run in the foreground, supplying the ongoing
         // notification to be shown to the user while in this state.
-        txService.startForeground(NOTIFICATION_ID_UPLOAD, mNotifBuilder.build());
+        txService.startForeground(NOTIFICATION_ID_NORMAR_UPLOAD, mNotifBuilder.build());
     }
 
     @Override
@@ -132,7 +131,7 @@ public class UploadNotificationProvider extends BaseNotificationProvider {
 
     @Override
     protected int getNotificationID() {
-        return NOTIFICATION_ID_UPLOAD;
+        return NOTIFICATION_ID_NORMAR_UPLOAD;
     }
 
     @Override

--- a/src/com/seafile/seadroid2/transfer/TransferService.java
+++ b/src/com/seafile/seadroid2/transfer/TransferService.java
@@ -6,6 +6,7 @@ import android.os.Binder;
 import android.os.IBinder;
 import android.util.Log;
 import com.seafile.seadroid2.account.Account;
+import com.seafile.seadroid2.notification.CameraUploadNotificationProvider;
 import com.seafile.seadroid2.notification.DownloadNotificationProvider;
 import com.seafile.seadroid2.notification.UploadNotificationProvider;
 
@@ -59,6 +60,20 @@ public class TransferService extends Service {
 
         List<DownloadTaskInfo> dInfos = getAllDownloadTaskInfos();
         for (DownloadTaskInfo info : dInfos) {
+            if (info.state.equals(TaskState.INIT)
+                    || info.state.equals(TaskState.TRANSFERRING))
+                return true;
+        }
+
+        return false;
+    }
+
+    public boolean cameraUploadServiecRunning() {
+        List<UploadTaskInfo> uInfos = getAllUploadTaskInfos();
+        for (UploadTaskInfo info : uInfos) {
+            if (info.isCopyToLocal)
+                continue;
+
             if (info.state.equals(TaskState.INIT)
                     || info.state.equals(TaskState.TRANSFERRING))
                 return true;
@@ -198,12 +213,42 @@ public class TransferService extends Service {
 
     // -------------------------- upload notification --------------------//
 
+    /**
+     * save {@link com.seafile.seadroid2.notification.UploadNotificationProvider} instance for normal files uploading
+     * @param provider
+     */
     public void saveUploadNotifProvider(UploadNotificationProvider provider) {
         uploadTaskManager.saveUploadNotifProvider(provider);
     }
 
+    /**
+     * save {@link com.seafile.seadroid2.notification.CameraUploadNotificationProvider} instance for camera files uploading
+     * @param provider
+     */
+    public void saveCameraUploadNotifProvider(CameraUploadNotificationProvider provider) {
+        uploadTaskManager.saveCameraUploadNotifProvider(provider);
+    }
+
+    /**
+     * check existence of the {@link com.seafile.seadroid2.notification.UploadNotificationProvider} instance for normal files uploading
+     *
+     * @return
+     *          true, if exist.
+     *          false, otherwise.
+     */
     public boolean hasUploadNotifProvider() {
         return uploadTaskManager.hasNotifProvider();
+    }
+
+    /**
+     * check existence of the {@link com.seafile.seadroid2.notification.CameraUploadNotificationProvider} instance for camera files uploading
+     *
+     * @return
+     *          true, if exist.
+     *          false, otherwise.
+     */
+    public boolean hasCameraUploadNotifProvider() {
+        return uploadTaskManager.hasCameraUploadNotifProvider();
     }
 
     public UploadNotificationProvider getUploadNotifProvider() {

--- a/src/com/seafile/seadroid2/transfer/UploadTaskManager.java
+++ b/src/com/seafile/seadroid2/transfer/UploadTaskManager.java
@@ -2,10 +2,10 @@ package com.seafile.seadroid2.transfer;
 
 import android.content.Intent;
 import android.support.v4.content.LocalBroadcastManager;
-import android.util.Log;
 import com.google.common.collect.Lists;
 import com.seafile.seadroid2.SeadroidApplication;
 import com.seafile.seadroid2.account.Account;
+import com.seafile.seadroid2.notification.CameraUploadNotificationProvider;
 import com.seafile.seadroid2.notification.UploadNotificationProvider;
 
 import java.util.List;
@@ -23,6 +23,8 @@ public class UploadTaskManager extends TransferManager implements UploadStateLis
     public static final String BROADCAST_FILE_UPLOAD_CANCELLED = "uploadCancelled";
 
     private static UploadNotificationProvider mNotifyProvider;
+    /** camera upload notification provider */
+    private static CameraUploadNotificationProvider mCameraUploadNotifyProvider;
 
     public int addTaskToQue(Account account, String repoID, String repoName, String dir, String filePath, boolean isUpdate, boolean isCopyToLocal) {
         if (repoID == null || repoName == null)
@@ -72,10 +74,14 @@ public class UploadTaskManager extends TransferManager implements UploadStateLis
         if (info == null)
             return;
 
-        // use isCopyToLocal as a flag to mark a camera photo upload task if false
-        // mark a file upload task if true
-        if (!info.isCopyToLocal)
+        // use isCopyToLocal as a flag to mark a camera photo upload task if false,
+        // mark a file upload task, otherwise.
+        if (!info.isCopyToLocal) {
+            if (mCameraUploadNotifyProvider != null) {
+                mCameraUploadNotifyProvider.updateNotification();
+            }
             return;
+        }
 
         //Log.d(DEBUG_TAG, "notify key " + info.repoID);
         if (mNotifyProvider != null) {
@@ -84,12 +90,42 @@ public class UploadTaskManager extends TransferManager implements UploadStateLis
 
     }
 
+    /**
+     * save {@link com.seafile.seadroid2.notification.UploadNotificationProvider} instance for normal files uploading
+     * @param provider
+     */
     public void saveUploadNotifProvider(UploadNotificationProvider provider) {
         mNotifyProvider = provider;
     }
 
+    /**
+     * save {@link com.seafile.seadroid2.notification.CameraUploadNotificationProvider} instance for camera uploading
+     * @param provider
+     */
+    public void saveCameraUploadNotifProvider(CameraUploadNotificationProvider provider) {
+        mCameraUploadNotifyProvider = provider;
+    }
+
+    /**
+     * check existence of the {@link com.seafile.seadroid2.notification.UploadNotificationProvider} instance for normal files uploading
+     *
+     * @return
+     *          false, if null.
+     *          true, otherwise.
+     */
     public boolean hasNotifProvider() {
         return mNotifyProvider != null;
+    }
+
+    /**
+     * check existence of the {@link com.seafile.seadroid2.notification.CameraUploadNotificationProvider} instance for camera files uploading
+     *
+     * @return
+     *          false, if null.
+     *          true, otherwise.
+     */
+    public boolean hasCameraUploadNotifProvider() {
+        return mCameraUploadNotifyProvider != null;
     }
 
     public UploadNotificationProvider getNotifProvider() {


### PR DESCRIPTION
fix #265

The system keeps all network connections open while in background, but does not deliver the data until the app resumes. 
In order to ensure continuous network communication for camera uploading, put the service in a foreground state, where the system considers it to be something the user is actively aware of
and thus not a candidate for killing when low on memory.

also
* fix a crash when uploading notification bar appears
