### PR TITLE
Fix on file uploaded null pointer exception

### DIFF
--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -1697,6 +1697,10 @@ public class BrowserActivity extends SherlockFragmentActivity
 
         UploadTaskInfo info = txService.getUploadTaskInfo(taskID);
 
+        if(info == null) {
+            return;
+        }
+
         String repoID = info.repoID;
         String dir = info.parentDir;
         if (currentPosition == 0


### PR DESCRIPTION
Fix on file uploaded null pointer exception

error log 
```
java.lang.NullPointerException
at com.seafile.seadroid2.ui.activity.BrowserActivity.onFileUploaded(BrowserActivity.java:1612)
at com.seafile.seadroid2.ui.activity.BrowserActivity.access$1400(BrowserActivity.java:90)
at com.seafile.seadroid2.ui.activity.BrowserActivity$TransferReceiver.onReceive(BrowserActivity.java:1673)
at android.support.v4.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:297)
at android.support.v4.content.LocalBroadcastManager.access$000(LocalBroadcastManager.java:46)
at android.support.v4.content.LocalBroadcastManager$1.handleMessage(LocalBroadcastManager.java:116)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:137)
at android.app.ActivityThread.main(ActivityThread.java:4921)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:511)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1027)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:794)
at dalvik.system.NativeStart.main(Native Method)
```
error occurs on Seafile 1.6.0 on Android 4.1 Galaxy S2 (GT-I9100).