### PR TITLE
fix getActionBar NoSuchMethodError

### DIFF
--- a/src/com/seafile/seadroid2/cameraupload/CameraUploadConfigActivity.java
+++ b/src/com/seafile/seadroid2/cameraupload/CameraUploadConfigActivity.java
@@ -3,12 +3,12 @@ package com.seafile.seadroid2.cameraupload;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v4.view.ViewPager.OnPageChangeListener;
 import android.view.View;
+import com.actionbarsherlock.app.SherlockFragmentActivity;
 import com.google.common.collect.Lists;
 import com.seafile.seadroid2.R;
 import com.seafile.seadroid2.SettingsManager;
@@ -27,7 +27,7 @@ import java.util.Map;
 /**
  * Camera upload configuration helper
  */
-public class CameraUploadConfigActivity extends FragmentActivity {
+public class CameraUploadConfigActivity extends SherlockFragmentActivity {
     public static final String DEBUG_TAG = "CameraUploadConfigActivity";
 
     private ViewPager mViewPager;
@@ -52,8 +52,8 @@ public class CameraUploadConfigActivity extends FragmentActivity {
 
         setContentView(R.layout.cuc_activity_layout);
 
-        if (getActionBar() != null)
-            getActionBar().hide();
+        if (getSupportActionBar() != null)
+            getSupportActionBar().hide();
 
         isChooseBothPages = getIntent().getBooleanExtra(SettingsFragment.CAMERA_UPLOAD_BOTH_PAGES, false);
         isChooseLibPage = getIntent().getBooleanExtra(SettingsFragment.CAMERA_UPLOAD_REMOTE_LIBRARY, false);


### PR DESCRIPTION
getActionBar is a method of api 11, so change to call getSupportActionBar instead.
Also make the class extends SherlockFragmentActivity to keep consistent with other classes.

error log
```
java.lang.NoSuchMethodError: com.seafile.seadroid2.cameraupload.CameraUploadConfigActivity.getActionBar
at com.seafile.seadroid2.cameraupload.CameraUploadConfigActivity.onCreate(CameraUploadConfigActivity.java:57)
at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1047)
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:1615)
at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:1667)
at android.app.ActivityThread.access$1500(ActivityThread.java:117)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:935)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:130)
at android.app.ActivityThread.main(ActivityThread.java:3687)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:507)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:842)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:600)
at dalvik.system.NativeStart.main(Native Method)
```
 name | info
--- | ---
App version | Seafile 1.6.0
OS version | Android 2.3.3 - 2.3.7
Device | Galaxy S (GT-I9000)