### PR TITLE
refactor open files method

### DIFF
--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -1363,9 +1363,9 @@ public class BrowserActivity extends SherlockFragmentActivity
             return;
         }
 
-        String mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(suffix);
+        String mime = Intent.normalizeMimeType(suffix);
         Intent open = new Intent(Intent.ACTION_VIEW);
-        open.setDataAndType((Uri.fromFile(file)), mime);
+        open.setDataAndTypeAndNormalize((Uri.fromFile(file)), mime);
 
         try {
             startActivity(open);

--- a/src/com/seafile/seadroid2/ui/dialog/OpenAsDialog.java
+++ b/src/com/seafile/seadroid2/ui/dialog/OpenAsDialog.java
@@ -38,23 +38,23 @@ public class OpenAsDialog extends DialogFragment {
                         Intent intent = new Intent(Intent.ACTION_VIEW);
                         switch (which) {
                         case OPEN_AS_TEXT:
-                            intent.setDataAndType((Uri.fromFile(file)), "text/*");
+                            intent.setDataAndTypeAndNormalize((Uri.fromFile(file)), "text/*");
                             startActivity(intent);
                             break;
                         case OPEN_AS_AUDIO:
-                            intent.setDataAndType((Uri.fromFile(file)), "audio/*");
+                            intent.setDataAndTypeAndNormalize((Uri.fromFile(file)), "audio/*");
                             startActivity(intent);
                             break;
                         case OPEN_AS_VIDEO:
-                            intent.setDataAndType((Uri.fromFile(file)), "video/*");
+                            intent.setDataAndTypeAndNormalize((Uri.fromFile(file)), "video/*");
                             startActivity(intent);
                             break;
                         case OPEN_AS_IMAGE:
-                            intent.setDataAndType((Uri.fromFile(file)), "image/*");
+                            intent.setDataAndTypeAndNormalize((Uri.fromFile(file)), "image/*");
                             startActivity(intent);
                             break;
                         case OPEN_AS_OTHER:
-                            intent.setDataAndType((Uri.fromFile(file)), "*/*");
+                            intent.setDataAndTypeAndNormalize((Uri.fromFile(file)), "*/*");
                             startActivity(intent);
                         default:
                             break;


### PR DESCRIPTION
as [normalizeMimeType](http://developer.android.com/reference/android/content/Intent.html#normalizeMimeType\(java.lang.String\)) and [setDataAndType](http://developer.android.com/reference/android/content/Intent.html#setDataAndType\(android.net.Uri, java.lang.String\)) said from official documents
>
1. All MIME types received from outside Android
(such as user input, or external sources like Bluetooth, NFC, or the Internet)
should be normalized before they are used to create an Intent.
2. MIME type and Uri scheme matching in the Android framework is case-sensitive, unlike the formal RFC definitions.
As a result, you should always write these elements with lower case letters,
or use normalizeMimeType(String) or normalizeScheme() or setDataAndTypeAndNormalize(Uri, String)
to ensure that they are converted to lower case.  

So change to use setDataAndTypeAndNormalize instead of setDataAndType

this seems like a way to fix #304, unfortunately, it was not the case which leaded up to the crash. But At least this patch supports a better way to implement opening files operations via intent.