### PR TITLE
correct download failed info

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -57,6 +57,9 @@
     <string name="uploaded">Uploaded</string>
     <string name="updated">Updated</string>
     <string name="download_failed">Download failed</string>
+    <string name="download_waiting">Download waiting</string>
+    <string name="download_finished">Download finished</string>
+    <string name="download_cancelled">Download cancelled</string>
     <string name="task_cancel">Cancel</string>
     <string name="task_retry">Retry</string>
     <string name="task_remove">Remove</string>
@@ -151,10 +154,10 @@
     <string name="tabs_activity">Activities</string>
     <string name="tabs_starred">Starred</string>
     <string name="provide_password">Provide the password for library \"%s\"</string>
-    <string name="upload_waiting">Waiting</string>
-    <string name="upload_finished">Finished</string>
-    <string name="upload_cancelled">Cancelled</string>
-    <string name="upload_failed">Failed</string>
+    <string name="upload_waiting">Upload waiting</string>
+    <string name="upload_finished">Upload finished</string>
+    <string name="upload_cancelled">Upload cancelled</string>
+    <string name="upload_failed">Upload failed</string>
     <string name="days_ago">%d days ago</string>
     <string name="hours_ago">%d hours ago</string>
     <string name="minutes_ago">%d minutes ago</string>

--- a/src/com/seafile/seadroid2/ui/adapter/TransferTaskAdapter.java
+++ b/src/com/seafile/seadroid2/ui/adapter/TransferTaskAdapter.java
@@ -29,10 +29,8 @@ public class TransferTaskAdapter extends BaseAdapter {
 
     private List<? extends TransferTaskInfo> mTransferTaskInfos;
     private Context mContext;
-    /**  0 mark as Download Task, 1 mark as Upload Task, the same convention with {@link TransferActivity #currentPosition} */
-    private int mTransferTaskType = -1;
-    public static final int DOWNLOAD_LIST_TAB = 0;
-    public static final int UPLOAD_LIST_TAB = 1;
+    private TaskType mTransferTaskType;
+    public enum TaskType {DOWNLOAD_TASK, UPLOAD_TASK}
 
     /**
      * Constructor of {@link TransferTaskAdapter}
@@ -50,8 +48,8 @@ public class TransferTaskAdapter extends BaseAdapter {
         this.mContext = context;
     }
 
-    public void setCurrentTab(int whichTab) {
-        this.mTransferTaskType = whichTab;
+    public void setCurrentTab(TaskType type) {
+        this.mTransferTaskType = type;
     }
 
     /*
@@ -112,11 +110,11 @@ public class TransferTaskAdapter extends BaseAdapter {
         int stateColor = R.color.light_black;
         long totalSize = 0l;
         long transferedSize = 0l;
-        if (mTransferTaskType == 0) {
+        if (mTransferTaskType.equals(TaskType.DOWNLOAD_TASK)) {
             DownloadTaskInfo dti = (DownloadTaskInfo) info;
             totalSize = dti.fileSize;
             transferedSize = dti.finished;
-        } else if (mTransferTaskType == 1) {
+        } else if (mTransferTaskType.equals(TaskType.UPLOAD_TASK)) {
             UploadTaskInfo uti = (UploadTaskInfo) info;
             totalSize = uti.totalSize;
             transferedSize = uti.uploadedSize;
@@ -144,27 +142,27 @@ public class TransferTaskAdapter extends BaseAdapter {
             viewHolder.progressBar.setVisibility(View.VISIBLE);
             break;
         case FINISHED:
-            if (mTransferTaskType == 0)
+            if (mTransferTaskType.equals(TaskType.DOWNLOAD_TASK))
                 stateStr = mContext.getString(R.string.download_finished);
-            else if (mTransferTaskType == 1)
+            else if (mTransferTaskType.equals(TaskType.UPLOAD_TASK))
                 stateStr = mContext.getString(R.string.upload_finished);
             stateColor = Color.BLACK;
             viewHolder.fileSize.setVisibility(View.VISIBLE);
             viewHolder.progressBar.setVisibility(View.INVISIBLE);
             break;
         case CANCELLED:
-            if (mTransferTaskType == 0)
+            if (mTransferTaskType.equals(TaskType.DOWNLOAD_TASK))
                 stateStr = mContext.getString(R.string.download_cancelled);
-            else if (mTransferTaskType == 1)
+            else if (mTransferTaskType.equals(TaskType.UPLOAD_TASK))
                 stateStr = mContext.getString(R.string.upload_cancelled);
             stateColor = Color.RED;
             viewHolder.fileSize.setVisibility(View.INVISIBLE);
             viewHolder.progressBar.setVisibility(View.INVISIBLE);
             break;
         case FAILED:
-            if (mTransferTaskType == 0)
+            if (mTransferTaskType.equals(TaskType.DOWNLOAD_TASK))
                 stateStr = mContext.getString(R.string.download_failed);
-            else if (mTransferTaskType == 1)
+            else if (mTransferTaskType.equals(TaskType.UPLOAD_TASK))
                 stateStr = mContext.getString(R.string.upload_failed);
             stateColor = Color.RED;
             viewHolder.fileSize.setVisibility(View.INVISIBLE);
@@ -196,7 +194,7 @@ public class TransferTaskAdapter extends BaseAdapter {
         }
         
         int iconID;
-        if (mTransferTaskType == 0) {
+        if (mTransferTaskType.equals(TaskType.DOWNLOAD_TASK)) {
             DownloadTaskInfo taskInfo = (DownloadTaskInfo) mTransferTaskInfos.get(position);
             iconID = Utils.getFileIcon(taskInfo.pathInRepo);
             // the three fileds is not dynamic
@@ -204,7 +202,7 @@ public class TransferTaskAdapter extends BaseAdapter {
             viewHolder.targetPath.setText(Utils.pathJoin(taskInfo.repoName, Utils.getParentPath(taskInfo.pathInRepo)));
             viewHolder.fileName.setText(Utils.fileNameFromPath(taskInfo.pathInRepo));
             updateTaskView(taskInfo, viewHolder);
-        } else if (mTransferTaskType == 1) {
+        } else if (mTransferTaskType.equals(TaskType.UPLOAD_TASK)) {
             UploadTaskInfo taskInfo = (UploadTaskInfo) mTransferTaskInfos.get(position);
             iconID = Utils.getFileIcon(taskInfo.localFilePath);
             String fullpath = taskInfo.repoName + taskInfo.parentDir;

--- a/src/com/seafile/seadroid2/ui/adapter/TransferTaskAdapter.java
+++ b/src/com/seafile/seadroid2/ui/adapter/TransferTaskAdapter.java
@@ -144,19 +144,28 @@ public class TransferTaskAdapter extends BaseAdapter {
             viewHolder.progressBar.setVisibility(View.VISIBLE);
             break;
         case FINISHED:
-            stateStr = mContext.getString(R.string.upload_finished);
+            if (mTransferTaskType == 0)
+                stateStr = mContext.getString(R.string.download_finished);
+            else if (mTransferTaskType == 1)
+                stateStr = mContext.getString(R.string.upload_finished);
             stateColor = Color.BLACK;
             viewHolder.fileSize.setVisibility(View.VISIBLE);
             viewHolder.progressBar.setVisibility(View.INVISIBLE);
             break;
         case CANCELLED:
-            stateStr = mContext.getString(R.string.upload_cancelled);
+            if (mTransferTaskType == 0)
+                stateStr = mContext.getString(R.string.download_cancelled);
+            else if (mTransferTaskType == 1)
+                stateStr = mContext.getString(R.string.upload_cancelled);
             stateColor = Color.RED;
             viewHolder.fileSize.setVisibility(View.INVISIBLE);
             viewHolder.progressBar.setVisibility(View.INVISIBLE);
             break;
         case FAILED:
-            stateStr = mContext.getString(R.string.upload_failed);
+            if (mTransferTaskType == 0)
+                stateStr = mContext.getString(R.string.download_failed);
+            else if (mTransferTaskType == 1)
+                stateStr = mContext.getString(R.string.upload_failed);
             stateColor = Color.RED;
             viewHolder.fileSize.setVisibility(View.INVISIBLE);
             viewHolder.progressBar.setVisibility(View.INVISIBLE);

--- a/src/com/seafile/seadroid2/ui/adapter/TransferTaskAdapter.java
+++ b/src/com/seafile/seadroid2/ui/adapter/TransferTaskAdapter.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
-/*
+/**
  * Adapter class for both uploading and downloading tasks
  */
 public class TransferTaskAdapter extends BaseAdapter {
@@ -52,7 +52,7 @@ public class TransferTaskAdapter extends BaseAdapter {
         this.mTransferTaskType = type;
     }
 
-    /*
+    /**
      * sort transfer list by task state, INIT goes to above, FINISHED goes to bottom.
      */
     private class TaskInfoComparator implements Comparator<TransferTaskInfo> {

--- a/src/com/seafile/seadroid2/ui/fragment/DownloadTaskFragment.java
+++ b/src/com/seafile/seadroid2/ui/fragment/DownloadTaskFragment.java
@@ -37,7 +37,7 @@ public class DownloadTaskFragment extends TransferTaskFragment {
         Log.d(DEBUG_TAG, "bind TransferService");
         List<DownloadTaskInfo> infos = txService.getAllDownloadTaskInfos();
         adapter = new TransferTaskAdapter(mActivity, infos);
-        adapter.setCurrentTab(TransferTaskAdapter.DOWNLOAD_LIST_TAB);
+        adapter.setCurrentTab(TransferTaskAdapter.TaskType.DOWNLOAD_TASK);
         mTransferTaskListView.setAdapter(adapter);
 
     }

--- a/src/com/seafile/seadroid2/ui/fragment/UploadTaskFragment.java
+++ b/src/com/seafile/seadroid2/ui/fragment/UploadTaskFragment.java
@@ -35,7 +35,7 @@ public class UploadTaskFragment extends TransferTaskFragment {
     protected void setUpTransferList() {
         List<UploadTaskInfo> infos = txService.getAllUploadTaskInfos();
         adapter = new TransferTaskAdapter(mActivity, infos);
-        adapter.setCurrentTab(TransferTaskAdapter.UPLOAD_LIST_TAB);
+        adapter.setCurrentTab(TransferTaskAdapter.TaskType.UPLOAD_TASK);
         mTransferTaskListView.setAdapter(adapter);
     }
 


### PR DESCRIPTION
When failed downloading a file, the failed info, like Chinese translation is incorrect.
The reason is that the original language resource is ambiguous, which is error-prone when contributors trying to translate their languages.

![failed_info_error](https://cloud.githubusercontent.com/assets/2975850/7466219/a65fb612-f311-11e4-9e21-7266e8e314e2.png)
