### PR TITLE
use native way to load drawables

### DIFF
--- a/src/com/seafile/seadroid2/ui/adapter/SeafItemAdapter.java
+++ b/src/com/seafile/seadroid2/ui/adapter/SeafItemAdapter.java
@@ -178,7 +178,7 @@ public class SeafItemAdapter extends BaseAdapter {
         viewHolder.progressBar.setVisibility(View.GONE);
         viewHolder.title.setText(repo.getTitle());
         viewHolder.subtitle.setText(repo.getSubtitle());
-        ImageLoader.getInstance().displayImage("drawable://" + repo.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
+        viewHolder.icon.setImageResource(repo.getIcon());
         viewHolder.action.setVisibility(View.INVISIBLE);
         return view;
     }
@@ -214,7 +214,7 @@ public class SeafItemAdapter extends BaseAdapter {
             viewHolder.progressBar.setVisibility(View.GONE);
 
             viewHolder.subtitle.setText(dirent.getSubtitle());
-            ImageLoader.getInstance().displayImage("drawable://" + dirent.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
+            viewHolder.icon.setImageResource(dirent.getIcon());
             viewHolder.action.setVisibility(View.VISIBLE);
             setDirAction(dirent, viewHolder, position);
         } else {
@@ -321,11 +321,11 @@ public class SeafItemAdapter extends BaseAdapter {
             ImageLoadingListener animateFirstListener = new AnimateFirstDisplayListener();
             String url = dataManager.getThumbnailLink(repoName, repoID, filePath, getThumbnailWidth());
             if (url == null) {
-                ImageLoader.getInstance().displayImage("drawable://" + dirent.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
+                viewHolder.icon.setImageResource(dirent.getIcon());
             } else
                 ImageLoader.getInstance().displayImage(url, viewHolder.icon, options, animateFirstListener);
         } else {
-            ImageLoader.getInstance().displayImage("drawable://" + dirent.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
+            viewHolder.icon.setImageResource(dirent.getIcon());
         }
 
         setFileAction(dirent, viewHolder, position, cacheExists);
@@ -354,7 +354,7 @@ public class SeafItemAdapter extends BaseAdapter {
         viewHolder.progressBar.setVisibility(View.GONE);
         viewHolder.title.setText(item.getTitle());
         viewHolder.subtitle.setText(item.getSubtitle());
-        ImageLoader.getInstance().displayImage("drawable://" + item.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
+        viewHolder.icon.setImageResource(item.getIcon());
         viewHolder.action.setVisibility(View.INVISIBLE);
         return view;
     }

--- a/src/com/seafile/seadroid2/ui/adapter/StarredItemAdapter.java
+++ b/src/com/seafile/seadroid2/ui/adapter/StarredItemAdapter.java
@@ -84,8 +84,7 @@ public class StarredItemAdapter extends BaseAdapter {
             viewHolder = (Viewholder) convertView.getTag();
         }
 
-        int iconID = item.getIcon();
-        viewHolder.icon.setImageResource(iconID);
+        viewHolder.icon.setImageResource(item.getIcon());
         viewHolder.title.setText(item.getTitle());
         viewHolder.subtitle.setText(item.getSubtitle());
 
@@ -105,11 +104,11 @@ public class StarredItemAdapter extends BaseAdapter {
             ImageLoadingListener animateFirstListener = new AnimateFirstDisplayListener();
             String url = mActivity.getDataManager().getThumbnailLink(((SeafStarredFile) item).getRepoID(), ((SeafStarredFile) item).getPath(), WidgetUtils.getThumbnailWidth());
             if (url == null) {
-                ImageLoader.getInstance().displayImage("drawable://" + item.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
+                viewHolder.icon.setImageResource(item.getIcon());
             } else
                 ImageLoader.getInstance().displayImage(url, viewHolder.icon, options, animateFirstListener);
         } else {
-            ImageLoader.getInstance().displayImage("drawable://" + item.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
+            viewHolder.icon.setImageResource(item.getIcon());
         }
 
         return view;


### PR DESCRIPTION
As noted by the [document of Universal Image Loader](https://github.com/nostra13/Android-Universal-Image-Loader#usage),

>NOTE: Use drawable:// only if you really need it! Always consider the native way to load drawables - ImageView.setImageResource(...) instead of using of ImageLoader.