### PR TITLE
Revert "use native way to load drawables"

### DIFF
--- a/src/com/seafile/seadroid2/ui/adapter/SeafItemAdapter.java
+++ b/src/com/seafile/seadroid2/ui/adapter/SeafItemAdapter.java
@@ -178,7 +178,7 @@ public class SeafItemAdapter extends BaseAdapter {
         viewHolder.progressBar.setVisibility(View.GONE);
         viewHolder.title.setText(repo.getTitle());
         viewHolder.subtitle.setText(repo.getSubtitle());
-        viewHolder.icon.setImageResource(repo.getIcon());
+        ImageLoader.getInstance().displayImage("drawable://" + repo.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
         viewHolder.action.setVisibility(View.INVISIBLE);
         return view;
     }
@@ -214,7 +214,7 @@ public class SeafItemAdapter extends BaseAdapter {
             viewHolder.progressBar.setVisibility(View.GONE);
 
             viewHolder.subtitle.setText(dirent.getSubtitle());
-            viewHolder.icon.setImageResource(dirent.getIcon());
+            ImageLoader.getInstance().displayImage("drawable://" + dirent.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
             viewHolder.action.setVisibility(View.VISIBLE);
             setDirAction(dirent, viewHolder, position);
         } else {
@@ -320,11 +320,11 @@ public class SeafItemAdapter extends BaseAdapter {
             ImageLoadingListener animateFirstListener = new AnimateFirstDisplayListener();
             String url = dataManager.getThumbnailLink(repoName, repoID, filePath, getThumbnailWidth());
             if (url == null) {
-                viewHolder.icon.setImageResource(dirent.getIcon());
+                ImageLoader.getInstance().displayImage("drawable://" + dirent.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
             } else
                 ImageLoader.getInstance().displayImage(url, viewHolder.icon, options, animateFirstListener);
         } else {
-            viewHolder.icon.setImageResource(dirent.getIcon());
+            ImageLoader.getInstance().displayImage("drawable://" + dirent.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
         }
 
         setFileAction(dirent, viewHolder, position, cacheExists);
@@ -353,7 +353,7 @@ public class SeafItemAdapter extends BaseAdapter {
         viewHolder.progressBar.setVisibility(View.GONE);
         viewHolder.title.setText(item.getTitle());
         viewHolder.subtitle.setText(item.getSubtitle());
-        viewHolder.icon.setImageResource(item.getIcon());
+        ImageLoader.getInstance().displayImage("drawable://" + item.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
         viewHolder.action.setVisibility(View.INVISIBLE);
         return view;
     }

--- a/src/com/seafile/seadroid2/ui/adapter/StarredItemAdapter.java
+++ b/src/com/seafile/seadroid2/ui/adapter/StarredItemAdapter.java
@@ -84,7 +84,8 @@ public class StarredItemAdapter extends BaseAdapter {
             viewHolder = (Viewholder) convertView.getTag();
         }
 
-        viewHolder.icon.setImageResource(item.getIcon());
+        int iconID = item.getIcon();
+        viewHolder.icon.setImageResource(iconID);
         viewHolder.title.setText(item.getTitle());
         viewHolder.subtitle.setText(item.getSubtitle());
 
@@ -104,11 +105,11 @@ public class StarredItemAdapter extends BaseAdapter {
             ImageLoadingListener animateFirstListener = new AnimateFirstDisplayListener();
             String url = mActivity.getDataManager().getThumbnailLink(((SeafStarredFile) item).getRepoID(), ((SeafStarredFile) item).getPath(), WidgetUtils.getThumbnailWidth());
             if (url == null) {
-                viewHolder.icon.setImageResource(item.getIcon());
+                ImageLoader.getInstance().displayImage("drawable://" + item.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
             } else
                 ImageLoader.getInstance().displayImage(url, viewHolder.icon, options, animateFirstListener);
         } else {
-            viewHolder.icon.setImageResource(item.getIcon());
+            ImageLoader.getInstance().displayImage("drawable://" + item.getIcon(), viewHolder.icon, WidgetUtils.iconOptions);
         }
 
         return view;


### PR DESCRIPTION
This revert fixes the following bug:

When scrolling images rapidly, the wrong thumbnails will be displayed for up to
a second.

steps to reproduce:
1. enter a directory with images
2. start scrolling before all thumbnails are loaded.
3. stop scrolling.
4. you will see the wrong thumbnails be displayed for a short while.

The reason for this is that ImageLoader makes the assumption that *all* access to
the ImageView is done through the ImageLoader. Bypassing the ImageLoader and
setting a Drawable directly will mess up the internal state keeping of the ImageLoader.

This reverts commit 60bdb83c54397bdcd8b1c8e896f6e82318c3e331.