### PR TITLE
Fix bug in certificate validation

### DIFF
--- a/src/com/seafile/seadroid2/SSLTrustManager.java
+++ b/src/com/seafile/seadroid2/SSLTrustManager.java
@@ -243,7 +243,7 @@ public final class SSLTrustManager {
             // where as the DefaultHostnameVerifier will always try to lookup IP addresses via the DNS.
             X509HostnameVerifier mHostnameVerifier = new BrowserCompatHostnameVerifier();
             try {
-                mHostnameVerifier.verify(account.getServerHost(), cert);
+                mHostnameVerifier.verify(account.getServerDomainName(), cert);
             } catch (SSLException e) {
                 throw new CertificateException();
             }

--- a/src/com/seafile/seadroid2/account/Account.java
+++ b/src/com/seafile/seadroid2/account/Account.java
@@ -43,6 +43,14 @@ public class Account implements Parcelable {
         return s.substring(0, s.indexOf('/'));
     }
 
+    public String getServerDomainName() {
+        String dn = getServerHost();
+        // strip port, like :8000 in 192.168.1.116:8000
+		if (dn.contains(":"))
+            dn = dn.substring(0, dn.indexOf(':'));
+        return dn;
+    }
+
     public String getEmail() {
         return email;
     }

--- a/src/com/seafile/seadroid2/account/Account.java
+++ b/src/com/seafile/seadroid2/account/Account.java
@@ -46,7 +46,7 @@ public class Account implements Parcelable {
     public String getServerDomainName() {
         String dn = getServerHost();
         // strip port, like :8000 in 192.168.1.116:8000
-		if (dn.contains(":"))
+        if (dn.contains(":"))
             dn = dn.substring(0, dn.indexOf(':'));
         return dn;
     }


### PR DESCRIPTION
Matches the server host name without port information against the
retrieved certificate. See
https://forum.seafile-server.org/t/bug-in-seafile-android-app-1-7-1/1911/3