### PR TITLE
fixed an mime type check error

### DIFF
--- a/src/com/seafile/seadroid2/util/Utils.java
+++ b/src/com/seafile/seadroid2/util/Utils.java
@@ -223,7 +223,7 @@ public class Utils {
 
         if (mimetype.contains("pdf")) {
             return R.drawable.file_pdf;
-        } else if (mimetype.contains("image")) {
+        } else if (mimetype.contains("image/")) {
             return R.drawable.file_image;
         } else if (mimetype.contains("text")) {
             return R.drawable.file_text;
@@ -294,7 +294,7 @@ public class Utils {
         String mime = MimeTypeMap.getSingleton().getMimeTypeFromExtension(suffix);
         if (mime == null)
             return false;
-        return mime.contains("image");
+        return mime.contains("image/");
     }
 
     public static boolean isNetworkOn() {


### PR DESCRIPTION
Files with a ".dmg" extension (e.g. Sublime Text Build 3083.dmg) are not correctly recognized by current mime type check logic.
The correct mime type for files with a ".dmg" extension should be "application/x-apple-diskimage", instead of "image", this error will lead up to a incorrect thumbnail preview, and incorrect behaviour in gallery.