### PR TITLE
clarify "share" vs. "export"  button

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -65,7 +65,7 @@
   <string name="file_action_star">Markieren</string>
   <string name="file_action_download">Herunterladen</string>
   <string name="file_action_update">Hochladen</string>
-  <string name="file_action_share">Freigeben</string>
+  <string name="file_action_share">Link freigeben</string>
   <string name="file_action_export">Exportieren</string>
   <string name="file_action_delete">Löschen</string>
   <string name="file_action_rename">Umbenennen</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -69,7 +69,7 @@
     <string name="file_action_star">Star</string>
     <string name="file_action_download">Download</string>
     <string name="file_action_update">Upload</string>
-    <string name="file_action_share">Share</string>
+    <string name="file_action_share">Share link</string>
     <string name="file_action_export">Export</string>
     <string name="file_action_delete">Delete</string>
     <string name="file_action_rename">Rename</string>


### PR DESCRIPTION
The "share" button shares a URL to the file, not the file itself.
Sharing the file itself is "export".

Since I've confused them multiple times, it might be a good idea to
make the meaning of the buttons a bit more clearer.