### PR TITLE
redesign gallery to avoid creating multiple thumbnails on server side

### DIFF
--- a/src/com/seafile/seadroid2/data/SeafPhoto.java
+++ b/src/com/seafile/seadroid2/data/SeafPhoto.java
@@ -10,13 +10,19 @@ public class SeafPhoto implements Serializable {
 
     /** display name */
     private String name;
-    /** link for loading thumbnail */
-    private String link;
+    /** repo name */
+    private String repoName;
+    /** repo id */
+    private String repoID;
+    /** dir */
+    private String dir;
     /** related {@link SeafDirent} */
     private SeafDirent dirent;
 
-    public SeafPhoto(String link, SeafDirent dirent) {
-        this.link = link;
+    public SeafPhoto(String repoName, String repoID, String dir, SeafDirent dirent) {
+        this.repoName = repoName;
+        this.repoID = repoID;
+        this.dir = dir;
         this.dirent = dirent;
         this.name = dirent.name;
     }
@@ -25,8 +31,16 @@ public class SeafPhoto implements Serializable {
         return name;
     }
 
-    public String getLink() {
-        return link;
+    public String getDir() {
+        return dir;
+    }
+
+    public String getRepoID() {
+        return repoID;
+    }
+
+    public String getRepoName() {
+        return repoName;
     }
 
     public SeafDirent getDirent() {

--- a/src/com/seafile/seadroid2/data/SeafPhoto.java
+++ b/src/com/seafile/seadroid2/data/SeafPhoto.java
@@ -14,15 +14,15 @@ public class SeafPhoto implements Serializable {
     private String repoName;
     /** repo id */
     private String repoID;
-    /** dir */
-    private String dir;
+    /** dir path */
+    private String dirPath;
     /** related {@link SeafDirent} */
     private SeafDirent dirent;
 
-    public SeafPhoto(String repoName, String repoID, String dir, SeafDirent dirent) {
+    public SeafPhoto(String repoName, String repoID, String dirPath, SeafDirent dirent) {
         this.repoName = repoName;
         this.repoID = repoID;
-        this.dir = dir;
+        this.dirPath = dirPath;
         this.dirent = dirent;
         this.name = dirent.name;
     }
@@ -31,8 +31,8 @@ public class SeafPhoto implements Serializable {
         return name;
     }
 
-    public String getDir() {
-        return dir;
+    public String getDirPath() {
+        return dirPath;
     }
 
     public String getRepoID() {

--- a/src/com/seafile/seadroid2/ui/WidgetUtils.java
+++ b/src/com/seafile/seadroid2/ui/WidgetUtils.java
@@ -157,8 +157,9 @@ public class WidgetUtils {
      * @param fileName
      * @param account
      */
-    public static void startGalleryActivity(Activity activity, String repoId, String path, String fileName, Account account) {
+    public static void startGalleryActivity(Activity activity, String repoName, String repoId, String path, String fileName, Account account) {
         Intent intent = new Intent(activity, GalleryActivity.class);
+        intent.putExtra("repoName", repoName);
         intent.putExtra("repoId", repoId);
         intent.putExtra("path", path);
         intent.putExtra("account", account);

--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -1269,7 +1269,7 @@ public class BrowserActivity extends SherlockFragmentActivity
         // because pic thumbnail under encrypted repo was not supported at the server side
         if (Utils.isViewableImage(fileName)
                 && repo != null && !repo.encrypted) {
-            WidgetUtils.startGalleryActivity(this, repoID, dirPath, fileName, account);
+            WidgetUtils.startGalleryActivity(this, repoName, repoID, dirPath, fileName, account);
             return;
         }
 
@@ -1454,7 +1454,7 @@ public class BrowserActivity extends SherlockFragmentActivity
         // because pic thumbnail under encrypted repo was not supported at the server side
         if (Utils.isViewableImage(starredFile.getTitle())
                 && repo != null && !repo.encrypted) {
-            WidgetUtils.startGalleryActivity(this, repoID, dirPath, starredFile.getTitle(), account);
+            WidgetUtils.startGalleryActivity(this, repoName, repoID, dirPath, starredFile.getTitle(), account);
             return;
         }
 

--- a/src/com/seafile/seadroid2/ui/activity/SearchActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/SearchActivity.java
@@ -365,7 +365,7 @@ public class SearchActivity extends SherlockFragmentActivity implements View.OnC
         // because pic thumbnail under encrypted repo was not supported at the server side
         if (Utils.isViewableImage(searchedFile.getTitle())
                 && repo != null && !repo.encrypted) {
-            WidgetUtils.startGalleryActivity(this, repoID, Utils.getParentPath(filePath), searchedFile.getTitle(), account);
+            WidgetUtils.startGalleryActivity(this, repoName, repoID, Utils.getParentPath(filePath), searchedFile.getTitle(), account);
             return;
         }
 

--- a/src/com/seafile/seadroid2/ui/adapter/GalleryAdapter.java
+++ b/src/com/seafile/seadroid2/ui/adapter/GalleryAdapter.java
@@ -75,11 +75,11 @@ public class GalleryAdapter extends PagerAdapter {
         final ProgressBar progressBar = (ProgressBar) contentView.findViewById(R.id.gallery_progress_bar);
         final String repoName = seafPhotos.get(position).getRepoName();
         final String repoID = seafPhotos.get(position).getRepoID();
-        final String filePath = Utils.pathJoin(seafPhotos.get(position).getDir(),
+        final String filePath = Utils.pathJoin(seafPhotos.get(position).getDirPath(),
                 seafPhotos.get(position).getName());
         final File file = dm.getLocalRepoFile(repoName, repoID, filePath);
         if (file.exists()) {
-            ImageLoader.getInstance().displayImage("file://" + file.getAbsolutePath(), photoView, options);
+            ImageLoader.getInstance().displayImage("file://" + file.getAbsolutePath().toString(), photoView, options);
         } else {
             ConcurrentAsyncTask.execute(new DownloadTask(++taskID, mAccount, repoName, repoID, filePath, new DownloadStateListener() {
                 @Override
@@ -89,9 +89,9 @@ public class GalleryAdapter extends PagerAdapter {
 
                 @Override
                 public void onFileDownloaded(int taskID) {
-                    //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingComplete");
+                    //Log.d(DEBUG_TAG, "DownloadTask >> onFileDownloaded");
                     ImageLoader.getInstance().displayImage("file://"
-                                    + dm.getLocalRepoFile(repoName, repoID, filePath).getAbsolutePath(),
+                                    + dm.getLocalRepoFile(repoName, repoID, filePath).getAbsolutePath().toString(),
                             photoView,
                             options,
                             new ImageLoadingListener() {
@@ -132,7 +132,7 @@ public class GalleryAdapter extends PagerAdapter {
 
                 @Override
                 public void onFileDownloadFailed(int taskID) {
-                    //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingFailed");
+                    //Log.d(DEBUG_TAG, "DownloadTask >> onFileDownloadFailed");
                     progressBar.setVisibility(View.INVISIBLE);
                     ImageLoader.getInstance().displayImage("drawable://" + R.drawable.gallery_loading_failed, photoView, options);
                 }

--- a/src/com/seafile/seadroid2/ui/adapter/GalleryAdapter.java
+++ b/src/com/seafile/seadroid2/ui/adapter/GalleryAdapter.java
@@ -11,13 +11,19 @@ import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.assist.FailReason;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingListener;
 import com.nostra13.universalimageloader.core.listener.ImageLoadingProgressListener;
+import com.seafile.seadroid2.ConcurrentAsyncTask;
 import com.seafile.seadroid2.R;
 import com.seafile.seadroid2.account.Account;
+import com.seafile.seadroid2.data.DataManager;
 import com.seafile.seadroid2.data.SeafPhoto;
+import com.seafile.seadroid2.transfer.DownloadStateListener;
+import com.seafile.seadroid2.transfer.DownloadTask;
 import com.seafile.seadroid2.ui.activity.GalleryActivity;
+import com.seafile.seadroid2.util.Utils;
 import uk.co.senab.photoview.PhotoView;
 import uk.co.senab.photoview.PhotoViewAttacher;
 
+import java.io.File;
 import java.util.List;
 
 /**
@@ -26,13 +32,18 @@ import java.util.List;
 public class GalleryAdapter extends PagerAdapter {
     public static final String DEBUG_TAG = "GalleryAdapter";
 
+    /** unique task id */
+    public static int taskID;
+
     private GalleryActivity mActivity;
     private List<SeafPhoto> seafPhotos;
     private LayoutInflater inflater;
     private DisplayImageOptions options;
+    private Account mAccount;
+    private DataManager dm;
 
     public GalleryAdapter(GalleryActivity context, Account account,
-                          List<SeafPhoto> photos) {
+                          List<SeafPhoto> photos, DataManager dataManager) {
         mActivity = context;
         seafPhotos = photos;
         inflater = context.getLayoutInflater();
@@ -44,6 +55,8 @@ public class GalleryAdapter extends PagerAdapter {
                 .considerExifParams(true)
                 .extraForDownloader(account)
                 .build();
+        mAccount = account;
+        dm = dataManager;
     }
 
     @Override
@@ -60,40 +73,71 @@ public class GalleryAdapter extends PagerAdapter {
         View contentView = inflater.inflate(R.layout.gallery_view_item, container, false);
         final PhotoView photoView = (PhotoView) contentView.findViewById(R.id.gallery_photoview);
         final ProgressBar progressBar = (ProgressBar) contentView.findViewById(R.id.gallery_progress_bar);
-        ImageLoader.getInstance().displayImage(seafPhotos.get(position).getLink(), photoView, options, new ImageLoadingListener() {
-            @Override
-            public void onLoadingStarted(String s, View view) {
-                //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingStarted");
-                progressBar.setVisibility(View.VISIBLE);
-            }
+        final String repoName = seafPhotos.get(position).getRepoName();
+        final String repoID = seafPhotos.get(position).getRepoID();
+        final String filePath = Utils.pathJoin(seafPhotos.get(position).getDir(),
+                seafPhotos.get(position).getName());
+        final File file = dm.getLocalRepoFile(repoName, repoID, filePath);
+        if (file.exists()) {
+            ImageLoader.getInstance().displayImage("file://" + file.getAbsolutePath(), photoView, options);
+        } else {
+            ConcurrentAsyncTask.execute(new DownloadTask(++taskID, mAccount, repoName, repoID, filePath, new DownloadStateListener() {
+                @Override
+                public void onFileDownloadProgress(int taskID) {
+                    progressBar.setVisibility(View.VISIBLE);
+                }
 
-            @Override
-            public void onLoadingFailed(String s, View view, FailReason failReason) {
-                //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingFailed");
-                progressBar.setVisibility(View.INVISIBLE);
-            }
+                @Override
+                public void onFileDownloaded(int taskID) {
+                    //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingComplete");
+                    ImageLoader.getInstance().displayImage("file://"
+                                    + dm.getLocalRepoFile(repoName, repoID, filePath).getAbsolutePath(),
+                            photoView,
+                            options,
+                            new ImageLoadingListener() {
+                                @Override
+                                public void onLoadingStarted(String s, View view) {
+                                    //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingStarted");
+                                    progressBar.setVisibility(View.VISIBLE);
+                                }
 
-            @Override
-            public void onLoadingComplete(String s, View view, Bitmap bitmap) {
-                //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingComplete");
-                progressBar.setVisibility(View.INVISIBLE);
-            }
+                                @Override
+                                public void onLoadingFailed(String s, View view, FailReason failReason) {
+                                    //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingFailed");
+                                    progressBar.setVisibility(View.INVISIBLE);
+                                }
 
-            @Override
-            public void onLoadingCancelled(String s, View view) {
-                //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingCancelled");
-                progressBar.setVisibility(View.INVISIBLE);
+                                @Override
+                                public void onLoadingComplete(String s, View view, Bitmap bitmap) {
+                                    //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingComplete");
+                                    progressBar.setVisibility(View.INVISIBLE);
+                                }
 
-            }
-        }, new ImageLoadingProgressListener() {
-            @Override
-            public void onProgressUpdate(String s, View view, int i, int i1) {
-                // There isn`t any way to get the actual loading bytes and total bytes with which
-                // could show the progress bar with precise percent
-                // see https://github.com/nostra13/Android-Universal-Image-Loader/issues/402 for details
-                progressBar.setVisibility(View.VISIBLE);
-            }
-        });
+                                @Override
+                                public void onLoadingCancelled(String s, View view) {
+                                    //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingCancelled");
+                                    progressBar.setVisibility(View.INVISIBLE);
+
+                                }
+                            }, new ImageLoadingProgressListener() {
+                                @Override
+                                public void onProgressUpdate(String s, View view, int i, int i1) {
+                                    // There isn`t any way to get the actual loading bytes and total bytes with which
+                                    // could show the progress bar with precise percent
+                                    // see https://github.com/nostra13/Android-Universal-Image-Loader/issues/402 for details
+                                    progressBar.setVisibility(View.VISIBLE);
+                                }
+                            });
+                }
+
+                @Override
+                public void onFileDownloadFailed(int taskID) {
+                    //Log.d(DEBUG_TAG, "ImageLoadingListener >> onLoadingFailed");
+                    progressBar.setVisibility(View.INVISIBLE);
+                    ImageLoader.getInstance().displayImage("drawable://" + R.drawable.gallery_loading_failed, photoView, options);
+                }
+            }));
+        }
 
         photoView.setOnPhotoTapListener(new PhotoViewAttacher.OnPhotoTapListener() {
             @Override


### PR DESCRIPTION
Photos shown in gallery are calculated by local cached files if they already exist, otherwise files will be asynchronously downloaded first. 