### PR TITLE
restore state of previous browsing

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -39,7 +39,7 @@
         <activity android:name="com.seafile.seadroid2.ui.activity.BrowserActivity"
                   android:label="@string/app_name"
                   android:theme="@style/Theme.SeafileTheme"
-                  android:launchMode="singleTask">
+                  android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -159,6 +159,16 @@ public class BrowserActivity extends SherlockFragmentActivity
     protected void onCreate(Bundle savedInstanceState) {
         requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
         super.onCreate(savedInstanceState);
+        if (!isTaskRoot()) {
+            final Intent intent = getIntent();
+            final String intentAction = getIntent().getAction();
+            if (intent.hasCategory(Intent.CATEGORY_LAUNCHER)
+                    && intentAction != null
+                    && intentAction.equals(Intent.ACTION_MAIN)) {
+                finish();
+                return;
+            }
+        }
         setContentView(R.layout.tabs_main);
 
         // Get the message from the intent


### PR DESCRIPTION
I have found that to restore previous browsing state instead of simply recreated a new Activity (Launcher Activity), one solution might be
1. set `android:launchMode="singleTop"` in AndroidManifest.xml
2. comment the method [protected void onNewIntent(Intent intent)](https://github.com/haiwen/seadroid/blob/master/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java#L623) in `BrowserActivity.java`.

But the potential risk is that **step 2** may introduce new bugs since it commented the code segment. So the following maintainer who are reading this should move the code segment in `onNewIntent` method to some suitable place, then you comment the method with no worry.

Reference
---
>
On some devices, pressing the launcher icon results in the current task being resumed, on others it results in the initial launch intent being fired (effectively restarting the app).
>
The behavior is caused by an issue that exists in some Android launchers since API 1. You can find details about the bug as well as possible solutions here: https://code.google.com/p/android/issues/detail?id=2373.
>
It's a relatively common issue on Samsung devices as well as other manufacturers that use a custom launcher/skin. I haven't seen the issue occur on a stock Android launcher.

read more 
[App restarts rather than resumes](http://stackoverflow.com/a/23220151/3962551)
[App completely restarting when launched by icon press in launcher](http://stackoverflow.com/a/21622266/3962551)