### PR TITLE
bugfix: early SAF usage by app might fail

### DIFF
--- a/src/com/seafile/seadroid2/account/Account.java
+++ b/src/com/seafile/seadroid2/account/Account.java
@@ -7,7 +7,7 @@ import android.util.Log;
 import com.google.common.base.Objects;
 import com.seafile.seadroid2.util.Utils;
 
-public class Account implements Parcelable {
+public class Account implements Parcelable, Comparable<Account> {
     private static final String DEBUG_TAG = "Account";
 
     // The full URL of the server, like 'http://gonggeng.org/seahub/' or 'http://gonggeng.org/'
@@ -149,5 +149,10 @@ public class Account implements Parcelable {
             .add("server", server)
             .add("user", email)
             .toString();
+    }
+
+    @Override
+    public int compareTo(Account other) {
+        return this.toString().compareTo(other.toString());
     }
 }


### PR DESCRIPTION
Previously it was assumed that SeafileProvider.queryRoots() would be called
before any of the other SeafileProvider.queryXXX() methods. That was a mistake.
At least SeafileProvider.queryDocument() might actually be called earlier.

This can cause problems if the Android OS has just been freshly rebooted and
the SAF is used for the first time. In that case

    SeafileProvider.isReachable

will still be empty. Thus doing an

    SeafileProvider.isReachable.get(account)

will return null. That breaks thinks, as can be witnessed e.g. by trying to use
latest Keepass2Android release with Seadroid after a fresh reboot.

This patches fixes that issue by converting the HashMap into a Set
(which is a more fitting data structure anyway).

(Making Account "Comparable" is just necessary to make the ConcurrentSkipListSet
work.)