### PR TITLE
Remember browse position when re-entering Seadroid via Launcher icon

### DIFF
--- a/src/com/seafile/seadroid2/account/Account.java
+++ b/src/com/seafile/seadroid2/account/Account.java
@@ -87,10 +87,10 @@ public class Account implements Parcelable, Comparable<Account> {
             return false;
 
         Account a = (Account)obj;
-        if (a.server == null || a.email == null)
+        if (a.server == null || a.email == null || a.token == null)
             return false;
 
-        return a.server.equals(this.server) && a.email.equals(this.email);
+        return a.server.equals(this.server) && a.email.equals(this.email) && a.token.equals(this.token);
     }
 
     public String getSignature() {

--- a/src/com/seafile/seadroid2/ui/activity/AccountDetailActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/AccountDetailActivity.java
@@ -255,16 +255,6 @@ public class AccountDetailActivity extends SherlockFragmentActivity {
         }
     }
 
-    private void startFilesActivity(Account account) {
-        Intent intent = new Intent(this, BrowserActivity.class);
-        intent.putExtra("server", account.server);
-        intent.putExtra("email", account.email);
-        intent.putExtra("token", account.token);
-
-        startActivity(intent);
-        finish(); // so the user will not return to this activity when press 'back'
-    }
-
     private class LoginTask extends AsyncTask<Void, Void, String> {
         Account loginAccount;
         SeafException err = null;
@@ -323,7 +313,9 @@ public class AccountDetailActivity extends SherlockFragmentActivity {
                 // save account to SharedPreference
                 accountManager.saveCurrentAccount(loginAccount);
 
-                startFilesActivity(loginAccount);
+                setResult(RESULT_OK);
+                finish();
+
             } else {
                 statusView.setText(result);
             }

--- a/src/com/seafile/seadroid2/ui/activity/AccountsActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/AccountsActivity.java
@@ -235,9 +235,8 @@ public class AccountsActivity extends SherlockFragmentActivity {
         Account account = accountManager.getCurrentAccount();
         if (account == null) {
             // force exit when current account was deleted
-            Intent i = new Intent();
-            i.setAction(Intent.ACTION_MAIN);
-            i.addCategory(Intent.CATEGORY_HOME);
+            Intent i = new Intent(this, BrowserActivity.class);
+            i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(i);
             finish();
         }

--- a/src/com/seafile/seadroid2/ui/activity/AccountsActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/AccountsActivity.java
@@ -41,6 +41,8 @@ import java.util.List;
 public class AccountsActivity extends SherlockFragmentActivity {
     private static final String DEBUG_TAG = "AccountsActivity";
 
+    public static final int DETAIL_ACTIVITY_REQUEST = 1;
+
     private ListView accountsView;
 
     private AccountManager accountManager;
@@ -183,8 +185,9 @@ public class AccountsActivity extends SherlockFragmentActivity {
         intent.putExtra(AccountManager.SHARED_PREF_EMAIL_KEY, account.email);
         intent.putExtra(AccountManager.SHARED_PREF_TOKEN_KEY, account.token);
 
-        startActivity(intent);
+        // first finish this activity, so the BrowserActivity is again "on top"
         finish();
+        startActivity(intent);
     }
 
     private void startEditAccountActivity(Account account) {
@@ -192,7 +195,21 @@ public class AccountsActivity extends SherlockFragmentActivity {
         intent.putExtra("server", account.server);
         intent.putExtra("email", account.email);
         intent.putExtra("isEdited", true);
-        startActivity(intent);
+        startActivityForResult(intent, DETAIL_ACTIVITY_REQUEST);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        switch (requestCode) {
+            case DETAIL_ACTIVITY_REQUEST:
+                if (resultCode == RESULT_OK) {
+                    Account account = accountManager.getCurrentAccount();
+                    startFilesActivity(account);
+                }
+                break;
+            default:
+                break;
+        }
     }
 
     @Override

--- a/src/com/seafile/seadroid2/ui/activity/AccountsActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/AccountsActivity.java
@@ -50,6 +50,7 @@ public class AccountsActivity extends SherlockFragmentActivity {
     private AccountAdapter adapter;
     private List<Account> accounts;
     private FileMonitorService mMonitorService;
+    private Account currentDefaultAccount;
     private ServiceConnection mMonitorConnection = new ServiceConnection() {
 
         @Override
@@ -74,7 +75,8 @@ public class AccountsActivity extends SherlockFragmentActivity {
         accountsView = (ListView) findViewById(R.id.account_list_view);
         accountManager = new AccountManager(this);
         avatarManager = new AvatarManager();
-       
+        currentDefaultAccount = accountManager.getCurrentAccount();
+
         View footerView = ((LayoutInflater) this
                 .getSystemService(Context.LAYOUT_INFLATER_SERVICE)).inflate(
                 R.layout.account_list_footer, null, false);
@@ -173,6 +175,13 @@ public class AccountsActivity extends SherlockFragmentActivity {
         accounts = accountManager.getAccountList();
         adapter.clear();
         adapter.setItems(accounts);
+
+        // if the user switched default account while we were in background,
+        // switch to BrowserActivity
+        Account newCurrentAccount = accountManager.getCurrentAccount();
+        if (newCurrentAccount != null && !newCurrentAccount.equals(currentDefaultAccount)) {
+            startFilesActivity(newCurrentAccount);
+        }
 
         loadAvatarUrls(48);
 

--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -632,11 +632,11 @@ public class BrowserActivity extends SherlockFragmentActivity
     @Override
     protected void onNewIntent(Intent intent) {
         Log.d(DEBUG_TAG, "onNewIntent");
-        String server = intent.getStringExtra("server");
-        String email = intent.getStringExtra("email");
+        String server = intent.getStringExtra(AccountManager.SHARED_PREF_SERVER_KEY);
+        String email = intent.getStringExtra(AccountManager.SHARED_PREF_EMAIL_KEY);
 
         // if the user started the Seadroid app from the Launcher, keep the old Activity
-        final String intentAction = getIntent().getAction();
+        final String intentAction = intent.getAction();
         if (intent.hasCategory(Intent.CATEGORY_LAUNCHER)
                 && intentAction != null
                 && intentAction.equals(Intent.ACTION_MAIN)) {

--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -638,6 +638,14 @@ public class BrowserActivity extends SherlockFragmentActivity
         // because it will restart the Activity when null
         if (server == null || email == null) return;
 
+        // if the user started the Seadroid app from the Launcher, keep the old Activity
+        final String intentAction = getIntent().getAction();
+        if (intent.hasCategory(Intent.CATEGORY_LAUNCHER)
+                && intentAction != null
+                && intentAction.equals(Intent.ACTION_MAIN)) {
+            return;
+        }
+
         Account selectedAccount = new Account(server, email);
         if (!account.equals(selectedAccount)) {
             finish();

--- a/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -634,9 +634,6 @@ public class BrowserActivity extends SherlockFragmentActivity
         Log.d(DEBUG_TAG, "onNewIntent");
         String server = intent.getStringExtra("server");
         String email = intent.getStringExtra("email");
-        // avoid lost browsing progress when resume App from launcher
-        // because it will restart the Activity when null
-        if (server == null || email == null) return;
 
         // if the user started the Seadroid app from the Launcher, keep the old Activity
         final String intentAction = getIntent().getAction();

--- a/src/com/seafile/seadroid2/ui/activity/UnlockGesturePasswordActivity.java
+++ b/src/com/seafile/seadroid2/ui/activity/UnlockGesturePasswordActivity.java
@@ -63,9 +63,8 @@ public class UnlockGesturePasswordActivity extends Activity {
     public void onBackPressed() {
         // stop default action (finishing the current activity) to be executed.
         // super.onBackPressed();
-        Intent i = new Intent();
-        i.setAction(Intent.ACTION_MAIN);
-        i.addCategory(Intent.CATEGORY_HOME);
+        Intent i = new Intent(this, BrowserActivity.class);
+        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         startActivity(i);
         finish();
     }


### PR DESCRIPTION
When tapping on the Seadroid Launcher icon, Seadroid currently always reverts back to
its "Home screen" (the list of repositories). Even if Seadroid was
already running and the user had already entered a specific folder.

This behaviour differs from most other apps. Usually the state of the app is preserved
if one re-enters it via the Launcher app.

This patch tries to do exactly that. The key place is BrowserActivity.onNewIntent()
In this method we have to decide whether to kill the old BrowserActivity and create a new
one; or to just keep the old one running.

Previously this was decided on the given account information. However this does not work
with the Launcher, as the account info is null if the intent comes from the Launcher.

I decided to use the Intent category/action for making that decision. If it is a MAIN
action, than it was called by the Launcher and the old instance shall be retained.

Therefore I had to convert UnlockGesturePasswordActivity and AccountsActivity to call
the BrowseActivity directly by its class name and not the action.

Note that a shorter fix would have been:

     -        if (!account.equals(selectedAccount)) {
     +        if (server == null || !account.equals(selectedAccount)) {

However BrowseActivity is started from a lot places, and I was a bit scared of creating new
bugs. This patch should hopefully have more controlled side effects.