### PR TITLE
Catch missing exceptions in AsyncTask

### DIFF
--- a/src/com/seafile/seadroid2/ui/fragment/SettingsFragment.java
+++ b/src/com/seafile/seadroid2/ui/fragment/SettingsFragment.java
@@ -540,11 +540,7 @@ public class SettingsFragment extends CustomPreferenceFragment {
                 String actInfo = seafConnection.getAccountInfo();
                 // parse raw data
                 accountInfo = accountMgr.parseAccountInfo(actInfo);
-            } catch (IOException e) {
-                e.printStackTrace();
-            } catch (SeafException e) {
-                e.printStackTrace();
-            } catch (JSONException e) {
+            } catch (Exception e) {
                 e.printStackTrace();
             }
 


### PR DESCRIPTION
getAccountInfo() might throw a com.github.kevinsawicki.http.HttpRequest$HttpRequestException
if DNS lookup fails. An uncatched exception in an AsyncTask causes the whole app to crash,
so better catch all of them.

Steps to reproduce:
1. start android emulator
2. disable network on your computer
3. start seafile in emulator
4. go to settings page
5. crash

Note that the "isNetworkOn()" check makes the bug not reproducible in "flight mode".