### PR TITLE
optimize item layout of slide expandable listview

### DIFF
--- a/res/layout-sw600dp/list_item_entry.xml
+++ b/res/layout-sw600dp/list_item_entry.xml
@@ -126,9 +126,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_share_btn"
@@ -165,9 +165,9 @@
                         android:layout_weight="1"
                         android:background="@drawable/btn_bg_selector_holo_dark">
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
 
                                 <ImageView
@@ -204,9 +204,9 @@
                         android:layout_weight="1"
                         android:background="@drawable/btn_bg_selector_holo_dark">
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
 
                                 <ImageView
@@ -244,9 +244,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_update_btn"
@@ -284,9 +284,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_download_btn"
@@ -324,10 +324,10 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
                                 android:orientation="vertical"
-                                android:gravity="center_vertical">
+                                android:gravity="center">
                                 <ImageView
                                         android:id="@+id/action_more_btn"
                                         android:layout_gravity="center_horizontal"
@@ -353,9 +353,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_copy_btn"
@@ -391,9 +391,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_move_btn"

--- a/res/layout-xlarge/list_item_entry.xml
+++ b/res/layout-xlarge/list_item_entry.xml
@@ -126,9 +126,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_share_btn"
@@ -165,9 +165,9 @@
                         android:layout_weight="1"
                         android:background="@drawable/btn_bg_selector_holo_dark">
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
 
                                 <ImageView
@@ -204,9 +204,9 @@
                         android:layout_weight="1"
                         android:background="@drawable/btn_bg_selector_holo_dark">
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
 
                                 <ImageView
@@ -244,9 +244,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_update_btn"
@@ -284,9 +284,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_download_btn"
@@ -324,9 +324,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:layout_centerInParent="true">
                                 <ImageView
                                         android:id="@+id/action_more_btn"
@@ -353,9 +353,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_copy_btn"
@@ -391,9 +391,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_move_btn"

--- a/res/layout/list_item_entry.xml
+++ b/res/layout/list_item_entry.xml
@@ -122,9 +122,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_share_btn"
@@ -161,9 +161,9 @@
                         android:layout_weight="1"
                         android:background="@drawable/btn_bg_selector_holo_dark">
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
 
                                 <ImageView
@@ -200,9 +200,9 @@
                         android:layout_weight="1"
                         android:background="@drawable/btn_bg_selector_holo_dark">
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
 
                                 <ImageView
@@ -240,9 +240,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_update_btn"
@@ -280,9 +280,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_download_btn"
@@ -320,10 +320,10 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
                                 android:orientation="vertical"
-                                android:gravity="center_vertical">
+                                android:gravity="center">
                                 <ImageView
                                         android:id="@+id/action_more_btn"
                                         android:layout_gravity="center_horizontal"
@@ -349,9 +349,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_copy_btn"
@@ -387,9 +387,9 @@
                         android:background="@drawable/btn_bg_selector_holo_dark">
 
                         <LinearLayout
-                                android:layout_width="@dimen/lv_expandable_element_width"
+                                android:layout_width="fill_parent"
                                 android:layout_height="@dimen/lv_expandable_element_height"
-                                android:gravity="center_vertical"
+                                android:gravity="center"
                                 android:orientation="vertical">
                                 <ImageView
                                         android:id="@+id/action_move_btn"


### PR DESCRIPTION
Optimized item layout of slide expandable listview in order to fix the messy layout under an encrypted repo. Position items in a rectangle area with same width, see the preview as below.
![image](https://cloud.githubusercontent.com/assets/2975850/10709799/62d2b3e2-7a6e-11e5-8f2b-c00c987a9c4a.png)

