### PR TITLE
fixed bug when files not opened in ACTIVITIES tab

### DIFF
--- a/src/com/seafile/seadroid2/ui/fragment/ActivitiesFragment.java
+++ b/src/com/seafile/seadroid2/ui/fragment/ActivitiesFragment.java
@@ -192,7 +192,7 @@ public class ActivitiesFragment extends SherlockFragment {
         intent.putExtra("filePath", path);
         intent.putExtra("account", getBrowserActivity().getAccount());
         intent.putExtra("taskID", taskID);
-        startActivityForResult(intent, BrowserActivity.DOWNLOAD_FILE_REQUEST);
+        getBrowserActivity().startActivityForResult(intent, BrowserActivity.DOWNLOAD_FILE_REQUEST);
     }
 
     private class MyWebViewClient extends WebViewClient {


### PR DESCRIPTION
If use `startActivityForResult` in Fragment, it will not call the `onActivityResult` of the parent Activity, so the file will not be opened after downloaded. 

The right way is to use `getBrowserActivity().startActivityForResult(intent, BrowserActivity.DOWNLOAD_FILE_REQUEST);`