### PR TITLE
Handle internal share links from other Seafile clients

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,6 +42,16 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Dev testing easily done with adb commands:
+                     adb shell am start -a android.intent.action.VIEW -d am start -a android.intent.action.VIEW -d seafile://openfile?repo_id=XXXpath=foo -->
+                <data
+                    android:scheme="seafile"
+                    android:host="*" />
+            </intent-filter>
         </activity>
         
         <activity


### PR DESCRIPTION
Integrate internal share links for the seafile desktop client. fix #452
### Testing by following command

```
am start -a android.intent.action.VIEW -d seafile://openfile?repo_id=bf00556c-6498-4fa9-a481-01ba10227111path=%2FCamera%20Uploads%2FP51024-173829.jpg
```
### Remaining issue
1. The current account of sender (sharing-internal-link-client) and receiver (handle-internal-link-client) should be the same, otherwise it will fail.
2. the launch mode of BrowserActivity (the launcher) is **singleTop**, which fails to handle the internal link when its current task has already been brought to the front, change it to **standard** will solve the issue but may introduce potential bugs
