### PR TITLE
Fix crash on Android 6.0 when freshly installed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,6 @@ ext {
     compileSdkVersion = 23
     supportLibVersion = '23.1.1'  // variable that can be referenced to keep support libs consistent
     minSdkVersion = 8
-    targetSdkVersion = 23
+    targetSdkVersion = 22
     buildToolsVersion = '23.0.2'
 }


### PR DESCRIPTION
Current Seadroid master breaks when freshly installed on Android 6.0 devices.

Steps to reproduce:

1. Use an Android 6.0 device
2. Delete Seadroid app (*)
3. build .apk
4. install .apk on device (e.g. via file manager) - you will not be shown list of required permissions on .apk install
5. create account in Seadroid
6. BrowseActivity will crash as Seadroid is lacking WRITE_EXTERNAL_STORAGE permission.

This patch fixes this issue by lowering the target level to 22. See commit message for more details.

(*) upgrading Seadroid will work, as previously granted permissions remain intact.