### PR TITLE
Fix crash when render material buttons on pre-L devices

### DIFF
--- a/app/src/main/res/layout/file_activity.xml
+++ b/app/src/main/res/layout/file_activity.xml
@@ -69,7 +69,6 @@
                 android:layout_marginLeft="@dimen/long_btn_margin_left"
                 android:layout_marginRight="@dimen/long_btn_margin_right"
                 android:text="@string/cancel"
-                android:textColor="@color/light_black"
                 android:textSize="@dimen/long_btn_txt_size"
                 android:theme="@style/NegativeButton" />
         </LinearLayout>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -34,9 +34,9 @@
         <item name="android:textColor">@color/fancy_orange</item>
     </style>
 
-    <style name="NegativeButton" parent="android:style/Widget.Material.Button">
+    <style name="NegativeButton" parent="Base.Widget.AppCompat.Button">
         <item name="android:colorButtonNormal">@color/fancy_dark_gray</item>
-        <item name="colorButtonNormal">@color/fancy_dark_gray</item>
+        <item name="android:textColor">@color/light_black</item>
     </style>
 
     <style name="ActionBarPopupThemeOverlay" parent="ThemeOverlay.AppCompat.Light" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -53,9 +53,9 @@
         <item name="android:textColor">@color/fancy_dark_black</item>
     </style>
 
-    <style name="NegativeButton" parent="android:style/Widget.Material.Button">
-        <item name="android:colorButtonNormal">@color/fancy_dark_gray</item>
+    <style name="NegativeButton" parent="Base.Widget.AppCompat.Button">
         <item name="colorButtonNormal">@color/fancy_dark_gray</item>
+        <item name="android:textColor">@color/light_black</item>
     </style>
 
     <style name="DialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">


### PR DESCRIPTION
fix `java.lang.UnsupportedOperationException` reported on Google Play Console.
use `Base.Widget.AppCompat.Button` as parent style to style negative buttons.

this should fix #478 