### PR TITLE
fix a multitouch zoom-out crash in the photo gallery

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/ui/HackyViewPager.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/HackyViewPager.java
@@ -1,0 +1,72 @@
+package com.seafile.seadroid2.ui;
+
+import android.content.Context;
+import android.support.v4.view.ViewPager;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+/**
+ * Found at http://stackoverflow.com/questions/7814017/is-it-possible-to-disable-scrolling-on-a-viewpager.
+ * Convenient way to temporarily disable ViewPager navigation while interacting with ImageView.
+ * 
+ * Julia Zudikova
+ */
+
+/**
+ * Hacky fix for Issue #4 and
+ * http://code.google.com/p/android/issues/detail?id=18990
+ * <p/>
+ * ScaleGestureDetector seems to mess up the touch events, which means that
+ * ViewGroups which make use of onInterceptTouchEvent throw a lot of
+ * IllegalArgumentException: pointerIndex out of range.
+ * <p/>
+ * There's not much I can do in my code for now, but we can mask the result by
+ * just catching the problem and ignoring it.
+ *
+ * @author Chris Banes
+ */
+public class HackyViewPager extends ViewPager {
+
+	private boolean isLocked;
+	
+    public HackyViewPager(Context context) {
+        super(context);
+        isLocked = false;
+    }
+
+    public HackyViewPager(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        isLocked = false;
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent ev) {
+    	if (!isLocked) {
+	        try {
+	            return super.onInterceptTouchEvent(ev);
+	        } catch (IllegalArgumentException e) {
+	            e.printStackTrace();
+	            return false;
+	        }
+    	}
+    	return false;
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        return !isLocked && super.onTouchEvent(event);
+    }
+
+	public void toggleLock() {
+		isLocked = !isLocked;
+	}
+
+	public void setLocked(boolean isLocked) {
+		this.isLocked = isLocked;
+	}
+
+	public boolean isLocked() {
+		return isLocked;
+	}
+
+}

--- a/app/src/main/java/com/seafile/seadroid2/ui/activity/GalleryActivity.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/activity/GalleryActivity.java
@@ -2,7 +2,6 @@ package com.seafile.seadroid2.ui.activity;
 
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.support.v4.view.ViewPager;
 import android.util.Log;
 import android.view.View;
 import android.view.WindowManager;
@@ -10,6 +9,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import com.google.common.collect.Lists;
+import com.seafile.seadroid2.ui.HackyViewPager;
 import com.seafile.seadroid2.util.ConcurrentAsyncTask;
 import com.seafile.seadroid2.R;
 import com.seafile.seadroid2.SeafException;
@@ -37,7 +37,7 @@ import java.util.List;
 public class GalleryActivity extends BaseActivity {
     public static final String DEBUG_TAG = "GalleryActivity";
 
-    private ViewPager mViewPager;
+    private HackyViewPager mViewPager;
     private LinearLayout mPageIndexContainer;
     private TextView mPageIndexTextView;
     private TextView mPageCountTextView;
@@ -89,11 +89,11 @@ public class GalleryActivity extends BaseActivity {
         mDeleteBtn.setOnClickListener(onClickListener);
         mStarBtn.setOnClickListener(onClickListener);
         mShareBtn.setOnClickListener(onClickListener);
-        mViewPager = (ViewPager) findViewById(R.id.gallery_pager);
+        mViewPager = (HackyViewPager) findViewById(R.id.gallery_pager);
         mViewPager.setPageTransformer(true, new ZoomOutPageTransformer());
         mViewPager.setOffscreenPageLimit(1);
 
-        mViewPager.setOnPageChangeListener(new ViewPager.OnPageChangeListener() {
+        mViewPager.setOnPageChangeListener(new HackyViewPager.OnPageChangeListener() {
             @Override
             public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
                 // page index starting from 1 instead of 0 in user interface, so plus one here

--- a/app/src/main/res/layout/gallery_activity_layout.xml
+++ b/app/src/main/res/layout/gallery_activity_layout.xml
@@ -4,7 +4,7 @@
              android:layout_height="fill_parent"
              android:layout_above="@+id/gallery_pager">
 
-        <android.support.v4.view.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
+        <com.seafile.seadroid2.ui.HackyViewPager xmlns:android="http://schemas.android.com/apk/res/android"
                                                  android:id="@+id/gallery_pager"
                                                  android:layout_width="match_parent"
                                                  android:layout_height="match_parent"


### PR DESCRIPTION
Steps to reproduce (tested on Android 5.1 and 6.0):
1. open image within seafile
2. zoom out with 3+ fingers aggressively multiple times
3. after 5-10 zoom-out gestures, the activity will crash (see exception below)

The cause is a apparently bug in the Android framework, which causes a crash when using
the PhotoView library. More details on the bug can be found in:

* https://github.com/chrisbanes/PhotoView#issues-with-viewgroups
* https://github.com/chrisbanes/PhotoView/issues/206

The workaround is to use a modified ViewPager provided by the author
of PhotoView.

01-31 23:29:16.255 10549-10549/? E/AndroidRuntime: FATAL EXCEPTION: main
                                                   Process: com.seafile.seadroid2, PID: 10549
                                                   java.lang.IllegalArgumentException: pointerIndex out of range
                                                       at android.view.MotionEvent.nativeGetAxisValue(Native Method)
                                                       at android.view.MotionEvent.getX(MotionEvent.java:2014)
                                                       at android.support.v4.view.MotionEventCompatEclair.getX(MotionEventCompatEclair.java:32)
                                                       at android.support.v4.view.MotionEventCompat$EclairMotionEventVersionImpl.getX(MotionEventCompat.java:110)
                                                       at android.support.v4.view.MotionEventCompat.getX(MotionEventCompat.java:462)
                                                       at android.support.v4.view.ViewPager.onInterceptTouchEvent(ViewPager.java:1916)
                                                       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:1961)
                                                       at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2406)
                                                       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2107)
                                                       at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2406)
                                                       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2107)
                                                       at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2406)
                                                       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2107)
                                                       at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2406)
                                                       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2107)
                                                       at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2406)
                                                       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2107)
                                                       at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2406)
                                                       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2107)
                                                       at com.android.internal.policy.impl.PhoneWindow$DecorView.superDispatchTouchEvent(PhoneWindow.java:2625)
                                                       at com.android.internal.policy.impl.PhoneWindow.superDispatchTouchEvent(PhoneWindow.java:1770)
                                                       at android.app.Activity.dispatchTouchEvent(Activity.java:2742)
                                                       at android.support.v7.view.WindowCallbackWrapper.dispatchTouchEvent(WindowCallbackWrapper.java:60)
                                                       at com.android.internal.policy.impl.PhoneWindow$DecorView.dispatchTouchEvent(PhoneWindow.java:2586)
                                                       at android.view.View.dispatchPointerEvent(View.java:8675)
                                                       at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent(ViewRootImpl.java:4129)
                                                       at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:3995)
                                                       at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:3550)
                                                       at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:3603)
                                                       at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:3569)
                                                       at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:3686)
                                                       at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:3577)
                                                       at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:3743)
                                                       at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:3550)
                                                       at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:3603)
                                                       at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:3569)
                                                       at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:3577)
                                                       at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:3550)
                                                       at android.view.ViewRootImpl.deliverInputEvent(ViewRootImpl.java:5813)
                                                       at android.view.ViewRootImpl.doProcessInputEvents(ViewRootImpl.java:5787)
                                                       at android.view.ViewRootImpl.enqueueInputEvent(ViewRootImpl.java:5758)
                                                       at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent(ViewRootImpl.java:5903)
                                                       at android.view.InputEventReceiver.dispatchInputEvent(InputEventReceiver.java:185)
                                                       at android.os.MessageQueue.nativePollOnce(Native Method)
                                                       at android.os.MessageQueue.next(MessageQueue.java:143)
                                                       at android.os.Looper.loop(Looper.java:122)
                                                       at android.app.ActivityThread.main(ActivityThread.java:5294)
                                                       at java.lang.reflect.Method.invoke(Native Method)
                                                       at java.lang.reflect.Method.invoke(Method.java:372)
                                                       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:904)
                                                       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:699)
01-31 23:29:16.269 3961-5035/system_process W/ActivityManager:   Force finishing activity 1 com.seafile.seadroid2/.ui.activity.GalleryActivity