### PR TITLE
Fix: Move dirent JSON cache from SQLite to filesystem

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
@@ -343,6 +343,9 @@ public class DataManager {
         File cache = getFileForReposCache();
         if (cache.exists()) {
             String json = Utils.readFile(cache);
+            if (json == null) {
+                return null;
+            }
             reposCache = parseRepos(json);
             return reposCache;
         }
@@ -511,6 +514,9 @@ public class DataManager {
     public List<SeafStarredFile> getStarredFiles() throws SeafException {
         String starredFiles = sc.getStarredFiles();
         Log.v(DEBUG_TAG, "Save starred files: " + starredFiles);
+        if (starredFiles == null) {
+            return null;
+        }
         dbHelper.saveCachedStarredFiles(account, starredFiles);
         return parseStarredFiles(starredFiles);
     }
@@ -518,6 +524,9 @@ public class DataManager {
     public List<SeafStarredFile> getCachedStarredFiles() {
         String starredFiles = dbHelper.getCachedStarredFiles(account);
         Log.v(DEBUG_TAG, "Get cached starred files: " + starredFiles);
+        if (starredFiles == null) {
+            return null;
+        }
         return parseStarredFiles(starredFiles);
     }
 
@@ -859,6 +868,9 @@ public class DataManager {
     }
 
     public ArrayList<SearchedFile> parseSearchResult(String json) {
+        if (json == null)
+            return null;
+
         try {
             JSONArray array = Utils.parseJsonArrayByKey(json, "results");
             if (array == null)

--- a/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
@@ -183,12 +183,12 @@ public class DataManager {
     }
 
     private File getFileForReposCache() {
-        String filename = "repos-" + (account.server + account.email).hashCode() + ".json";
+        String filename = "repos-" + (account.server + account.email).hashCode() + ".dat";
         return new File(getExternalCacheDirectory() + "/" + filename);
     }
 
     private File getFileForDirentCache(String dirID) {
-        String filename = "dirent-" + dirID + ".json";
+        String filename = "dirent-" + dirID + ".dat";
         return new File(getExternalCacheDirectory() + "/" + filename);
     }
 

--- a/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
@@ -316,14 +316,6 @@ public class DataManager {
         }
     }
 
-    public List<SeafRepo> getCachedRepos() {
-        return reposCache;
-    }
-
-    public SeafRepo getCachedRepo(int position) {
-        return reposCache.get(position);
-    }
-
     public SeafRepo getCachedRepoByID(String id) {
         List<SeafRepo> cachedRepos = getReposFromCache();
         if (cachedRepos == null) {

--- a/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
@@ -408,6 +408,7 @@ public class DataManager {
             }
             return dirents;
         } catch (JSONException e) {
+            Log.e(DEBUG_TAG, "Could not parse cached dirent", e);
             return null;
         }
     }
@@ -427,6 +428,7 @@ public class DataManager {
             }
             return starredFiles;
         } catch (JSONException e) {
+            Log.e(DEBUG_TAG, "Could not parse cached starred files", e);
             return null;
         }
     }

--- a/app/src/main/java/com/seafile/seadroid2/data/DatabaseHelper.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/DatabaseHelper.java
@@ -427,7 +427,6 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public void saveDirents(String repoID, String path, String dirID) {
-        removeCachedDirents(repoID, path);
         // Create a new map of values, where column names are the keys
         ContentValues values = new ContentValues();
         values.put(DIRENTS_CACHE_COLUMN_REPO_ID, repoID);
@@ -482,4 +481,40 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 
         return dirID;
     }
+
+    /**
+     * Return the number of cached dirs that reference a specific dirID.
+     * Used for cache cleaning.
+     *
+     * @param dirID
+     * @return
+     */
+    public int getCachedDirentUsage(String dirID) {
+        String[] projection = { DIRENTS_CACHE_COLUMN_DIR_ID };
+
+        String selectClause = String.format("%s = ?",
+                DIRENTS_CACHE_COLUMN_DIR_ID);
+
+        String[] selectArgs = { dirID };
+
+        Cursor cursor = database.query(
+                DIRENTS_CACHE_TABLE_NAME,
+                projection,
+                selectClause,
+                selectArgs,
+                null,   // don't group the rows
+                null,   // don't filter by row groups
+                null);  // The sort order
+
+        if (!cursor.moveToFirst()) {
+            cursor.close();
+            return 0;
+        }
+
+        int count = cursor.getCount();
+        cursor.close();
+
+        return count;
+    }
+
 }

--- a/app/src/main/java/com/seafile/seadroid2/data/DatabaseHelper.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/DatabaseHelper.java
@@ -18,7 +18,7 @@ import com.seafile.seadroid2.account.Account;
 public class DatabaseHelper extends SQLiteOpenHelper {
     private static final String DEBUG_TAG = "DatabaseHelper";
     // If you change the database schema, you must increment the database version.
-    public static final int DATABASE_VERSION = 6;
+    public static final int DATABASE_VERSION = 7;
     public static final String DATABASE_NAME = "data.db";
 
     // FileCache table
@@ -52,7 +52,6 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private static final String DIRENTS_CACHE_COLUMN_REPO_ID = "repo_id";
     private static final String DIRENTS_CACHE_COLUMN_PATH = "path";
     private static final String DIRENTS_CACHE_COLUMN_DIR_ID = "dir_id";
-    private static final String DIRENTS_CACHE_COLUMN_CONTENT = "content";
 
     private static final String SQL_CREATE_FILECACHE_TABLE =
         "CREATE TABLE " + FILECACHE_TABLE_NAME + " ("
@@ -82,8 +81,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         + DIRENTS_CACHE_COLUMN_ID + " INTEGER PRIMARY KEY, "
         + DIRENTS_CACHE_COLUMN_REPO_ID + " TEXT NOT NULL, "
         + DIRENTS_CACHE_COLUMN_PATH + " TEXT NOT NULL, "
-        + DIRENTS_CACHE_COLUMN_DIR_ID + " TEXT NOT NULL, "
-        + DIRENTS_CACHE_COLUMN_CONTENT + " TEXT NOT NULL);";
+        + DIRENTS_CACHE_COLUMN_DIR_ID + " TEXT NOT NULL);";
 
     // Use only single dbHelper to prevent multi-thread issue and db is closed exception
     // Reference http://stackoverflow.com/questions/2493331/what-are-the-best-practices-for-sqlite-on-android
@@ -428,14 +426,13 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         database.insert(STARRED_FILECACHE_TABLE_NAME, null, values);
     }
 
-    public void saveDirents(String repoID, String path, String dirID, String content) {
+    public void saveDirents(String repoID, String path, String dirID) {
         removeCachedDirents(repoID, path);
         // Create a new map of values, where column names are the keys
         ContentValues values = new ContentValues();
         values.put(DIRENTS_CACHE_COLUMN_REPO_ID, repoID);
         values.put(DIRENTS_CACHE_COLUMN_PATH, path);
         values.put(DIRENTS_CACHE_COLUMN_DIR_ID, dirID);
-        values.put(DIRENTS_CACHE_COLUMN_CONTENT, content);
 
         // Insert the new row, returning the primary key value of the new row
         database.insert(DIRENTS_CACHE_TABLE_NAME, null, values);
@@ -455,10 +452,9 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         database.delete(STARRED_FILECACHE_TABLE_NAME, whereClause, new String[] { account.getSignature() });
     }
 
-    public Pair<String, String> getCachedDirents(String repoID, String path) {
+    public String getCachedDirents(String repoID, String path) {
         String[] projection = {
-            DIRENTS_CACHE_COLUMN_DIR_ID,
-            DIRENTS_CACHE_COLUMN_CONTENT
+            DIRENTS_CACHE_COLUMN_DIR_ID
         };
 
         String selectClause = String.format("%s = ? and %s = ?",
@@ -482,9 +478,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         }
 
         String dirID = cursor.getString(0);
-        String content = cursor.getString(1);
         cursor.close();
 
-        return new Pair<String, String>(dirID, content);
+        return dirID;
     }
 }

--- a/app/src/main/java/com/seafile/seadroid2/data/DatabaseHelper.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/DatabaseHelper.java
@@ -455,20 +455,6 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         database.delete(STARRED_FILECACHE_TABLE_NAME, whereClause, new String[] { account.getSignature() });
     }
 
-    public String getDirents(String repoID, String path, String dirID) {
-        Pair<String, String> ret = getCachedDirents(repoID, path);
-        if (ret == null) {
-            return null;
-        }
-
-        if (dirID != null && !ret.first.equals(dirID)) {
-            // cache is out of date
-            return null;
-        }
-
-        return ret.second;
-    }
-
     public Pair<String, String> getCachedDirents(String repoID, String path) {
         String[] projection = {
             DIRENTS_CACHE_COLUMN_DIR_ID,

--- a/app/src/main/java/com/seafile/seadroid2/util/Utils.java
+++ b/app/src/main/java/com/seafile/seadroid2/util/Utils.java
@@ -119,23 +119,6 @@ public class Utils {
         }
     }
 
-    /** Read input stream and convert the content to string.
-     */
-    public static String readIt(InputStream stream) throws IOException,
-            UnsupportedEncodingException {
-        Reader reader = new InputStreamReader(stream, "UTF-8");
-        char[] buffer = new char[1024];
-        StringBuilder responseStrBuilder = new StringBuilder();
-
-        while (true) {
-            int len = reader.read(buffer, 0, 1024);
-            if (len == -1)
-                break;
-            responseStrBuilder.append(buffer, 0, len);
-        }
-        return responseStrBuilder.toString();
-    }
-
     public static String readFile(File file) {
         Reader reader = null;
         try {

--- a/app/src/main/java/com/seafile/seadroid2/util/Utils.java
+++ b/app/src/main/java/com/seafile/seadroid2/util/Utils.java
@@ -14,6 +14,7 @@ import android.net.NetworkInfo.DetailedState;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.OpenableColumns;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.text.format.DateFormat;
 import android.util.Log;
@@ -91,13 +92,7 @@ public class Utils {
         }
     }
 
-    public static JSONArray parseJsonArrayByKey(String json, String key) throws JSONException {
-        if (json == null) {
-            // the caller should not give null
-            Log.w(DEBUG_TAG, "null in parseJsonArrayByKey");
-            return null;
-        }
-
+    public static JSONArray parseJsonArrayByKey(@NonNull String json, @NonNull String key) throws JSONException {
         String value = new JSONObject(json).optString(key);
         if (!TextUtils.isEmpty(value))
             return parseJsonArray(value);
@@ -105,13 +100,7 @@ public class Utils {
             return null;
     }
 
-    public static JSONArray parseJsonArray(String json) {
-        if (json == null) {
-         // the caller should not give null
-            Log.w(DEBUG_TAG, "null in parseJsonArray");
-            return null;
-        }
-
+    public static JSONArray parseJsonArray(@NonNull String json) {
         try {
             return (JSONArray) new JSONTokener(json).nextValue();
         } catch (Exception e) {

--- a/app/src/main/java/com/seafile/seadroid2/util/Utils.java
+++ b/app/src/main/java/com/seafile/seadroid2/util/Utils.java
@@ -115,6 +115,7 @@ public class Utils {
         try {
             return (JSONArray) new JSONTokener(json).nextValue();
         } catch (Exception e) {
+            Log.e(DEBUG_TAG, "Could not parse json file", e);
             return null;
         }
     }


### PR DESCRIPTION
* Don't store JSON content in SQL, instead write it out into files. They are now stored in the same place as the repo cache is already stored (.../Seafile/cache/dirent-$HASH.json).
* database layout change (DATABASE_VERSION++)
* Some trivial cleanup patches

fixes issue #475 where the JSON content of a directory was sufficiently large to trip up the sqlite database on Android.

Side notes:
* I think storing repo or dirent cache in External Storage, where other apps can read them, might a mistake. That data might be too private. A better place would be Context.getCacheDir(), where other apps have no access to.
* Another thought was regarding cache cleaning. Obviously any downloaded files should remain persistent as long as possible. But removing older thumbnails and repo/dirent cache file from time to time might be a good idea.

I wish you all happy New Year holidays! :-)