### PR TITLE
A couple of fixes for the Seafile DocumentProvider implementation

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/monitor/SeafileObserver.java
+++ b/app/src/main/java/com/seafile/seadroid2/monitor/SeafileObserver.java
@@ -99,17 +99,14 @@ public class SeafileObserver implements FileAlterationListener {
 
     @Override
     public void onDirectoryChange(File directory) {
-        Log.v(DEBUG_TAG, directory.getPath() + " was modified!");
     }
 
     @Override
     public void onDirectoryCreate(File directory) {
-        Log.v(DEBUG_TAG, directory.getPath() + " was created!");
     }
 
     @Override
     public void onDirectoryDelete(File directory) {
-        Log.v(DEBUG_TAG, directory.getPath() + " was deleted!");
     }
 
     @Override
@@ -142,7 +139,6 @@ public class SeafileObserver implements FileAlterationListener {
 
     @Override
     public void onFileCreate(File file) {
-        Log.v(DEBUG_TAG, file.getPath() + " was created!");
     }
 
     @Override

--- a/app/src/main/java/com/seafile/seadroid2/monitor/SeafileObserver.java
+++ b/app/src/main/java/com/seafile/seadroid2/monitor/SeafileObserver.java
@@ -7,16 +7,20 @@ import java.util.Map;
 import org.apache.commons.io.monitor.FileAlterationListener;
 import org.apache.commons.io.monitor.FileAlterationObserver;
 
+import android.os.AsyncTask;
 import android.util.Log;
 
 import com.google.common.collect.Maps;
 import com.seafile.seadroid2.account.Account;
 import com.seafile.seadroid2.data.DataManager;
 import com.seafile.seadroid2.data.SeafCachedFile;
+import com.seafile.seadroid2.util.ConcurrentAsyncTask;
 import com.seafile.seadroid2.util.Utils;
 
 public class SeafileObserver implements FileAlterationListener {
     private static final String DEBUG_TAG = "SeafileObserver";
+
+    private static final int DELAY_UPLOAD_PERIOD = 5 * 1000;
 
     private Account account;
     private DataManager dataManager;
@@ -120,6 +124,15 @@ public class SeafileObserver implements FileAlterationListener {
             recentDownloadedFiles.removeRecentDownloadedFile(path);
         }
 
+        // We don't want to upload files that are still being modified.
+        // So only upload files that are at stable for least DELAY_UPLOAD_PERIOD
+        // otherwise wait a bit.
+        if (Math.abs(System.currentTimeMillis() - file.lastModified()) < DELAY_UPLOAD_PERIOD) {
+            Log.d(DEBUG_TAG, path + " delaying upload");
+            ConcurrentAsyncTask.execute(new DelayUpload(), file);
+            return;
+        }
+
         Log.d(DEBUG_TAG, path + " was modified!");
         SeafCachedFile cachedFile = watchedFiles.get(path);
         if (cachedFile != null) {
@@ -150,6 +163,20 @@ public class SeafileObserver implements FileAlterationListener {
     public void onStop(FileAlterationObserver fao) {
         Log.v(DEBUG_TAG, fao.toString() + " finished checking event!");
     }
+
+    class DelayUpload extends AsyncTask<File, Void, Void> {
+
+        @Override
+        protected Void doInBackground(File... params) {
+            try {
+                Thread.sleep(DELAY_UPLOAD_PERIOD);
+            } finally {
+                SeafileObserver.this.onFileChange(params[0]);
+                return null;
+            }
+        }
+    }
+
 
     /**
      * When user downloads a file, the outdated file is replaced, so the onFileChange signal would

--- a/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -294,7 +294,7 @@ public class SeafileProvider extends DocumentsProvider {
             SeafRepo repo = dm.getCachedRepoByID(repoId);
 
             // encrypted repos are not supported (we can't ask the user for the passphrase)
-            if (repo.encrypted) {
+            if (repo == null || repo.encrypted) {
                 throw new FileNotFoundException();
             }
 

--- a/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -580,6 +580,32 @@ public class SeafileProvider extends DocumentsProvider {
         }
     }
 
+    @Override
+    public void deleteDocument(String documentId) throws FileNotFoundException {
+        Log.d(DEBUG_TAG, "deleteDocument: " + documentId);
+
+        if (!Utils.isNetworkOn())
+            throw new FileNotFoundException();
+
+        String repoId = DocumentIdParser.getRepoIdFromId(documentId);
+        if (repoId.isEmpty()) {
+            throw new FileNotFoundException();
+        }
+
+        String path = docIdParser.getPathFromId(documentId);
+        DataManager dm = createDataManager(documentId);
+
+        try {
+
+            // only support deleting files for now
+            dm.delete(repoId, path, false);
+
+        } catch (SeafException e) {
+            Log.d(DEBUG_TAG, "could not delete file", e);
+            throw new FileNotFoundException();
+        }
+    }
+
     /**
      * Create a MatrixCursor with the option to enable the extraLoading flag.
      *
@@ -814,7 +840,7 @@ public class SeafileProvider extends DocumentsProvider {
             if (entry.isDir()) {
                 flags |= Document.FLAG_DIR_SUPPORTS_CREATE;
             } else {
-                flags |= Document.FLAG_SUPPORTS_WRITE;
+                flags |= Document.FLAG_SUPPORTS_WRITE | Document.FLAG_SUPPORTS_DELETE;
             }
         }
 

--- a/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -420,7 +420,7 @@ public class SeafileProvider extends DocumentsProvider {
             throw new FileNotFoundException();
         }
 
-        Log.d(DEBUG_TAG, "dowloading file " + path);
+        Log.d(DEBUG_TAG, "dowloading/refreshing file " + path);
         int taskID = txService.addDownloadTask(dm.getAccount(), repo.getName(), repoId, path);
 
         DownloadTaskInfo info = null;

--- a/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -201,6 +201,11 @@ public class SeafileProvider extends DocumentsProvider {
                 KEEP_ALIVE_TIME_UNIT,
                 mDecodeWorkQueue);
 
+        // assume at the beginning that all accounts are reachable
+        for(Account a: accountManager.getAccountList()) {
+            reachableAccounts.add(a);
+        }
+
         return true;
     }
 

--- a/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -364,7 +364,6 @@ public class SeafileProvider extends DocumentsProvider {
 
             String parentPath = Utils.getParentPath(path);
             List<SeafDirent> dirents = dm.getCachedDirents(repo.getID(), parentPath);
-            List<SeafStarredFile> starredFiles = dm.getCachedStarredFiles();
 
             if (dirents != null) {
                 // the file is in the dirent of the parent directory
@@ -375,13 +374,16 @@ public class SeafileProvider extends DocumentsProvider {
                         includeDirent(result, dm, repo.getID(), parentPath, entry);
                     }
                 }
-            } else if (starredFiles != null) {
+            } else {
                 //maybe the requested file is a starred file?
+                List<SeafStarredFile> starredFiles = dm.getCachedStarredFiles();
+                if (starredFiles != null) {
 
-                // look for the requested file in the list of starred files
-                for(SeafStarredFile file: starredFiles) {
-                    if (file.getPath().equals(path)) {
-                        includeStarredFileDirent(result, dm, file);
+                    // look for the requested file in the list of starred files
+                    for(SeafStarredFile file: starredFiles) {
+                        if (file.getPath().equals(path)) {
+                            includeStarredFileDirent(result, dm, file);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
A while ago TitantiumBackup (a popular backup tool for Android) got support for the SAF (*). Unfortunately, up till now it doesn't really work with Seadroid. This is because Titanium's advanced use of the SAF triggers hidden bugs in Seadroid's DocumentProvider implementation. These patches fix them. :)

Note that I would still consider it experimental to actually use Seadroid as a storage backend for Titatium backup. The biggest open issue is that Titanium Backup uses the SAF so intensely that Seadroid will likely run into the SeaHub rate limiting of 600 requests/min (HTTP error 429). Unfortunately there is no simple fix to address this.

(*) It's well hidden in that thing they call a settings dialog. Dig deep and you'll find it.