### PR TITLE
fixes issue #491

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/cameraupload/CameraSyncAdapter.java
+++ b/app/src/main/java/com/seafile/seadroid2/cameraupload/CameraSyncAdapter.java
@@ -496,6 +496,12 @@ public class CameraSyncAdapter extends AbstractThreadedSyncAdapter {
             int dataColumn = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATA);
             int bucketColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.ImageColumns.BUCKET_DISPLAY_NAME);
 
+            // some inconsistency in the Media Provider? Ignore and continue
+            if (cursor.getString(dataColumn) == null) {
+                syncResult.stats.numSkippedEntries++;
+                continue;
+            }
+
             File file = new File(cursor.getString(dataColumn));
             String bucketName = cursor.getString(bucketColumn);
 

--- a/app/src/main/java/com/seafile/seadroid2/cameraupload/GalleryBucketUtils.java
+++ b/app/src/main/java/com/seafile/seadroid2/cameraupload/GalleryBucketUtils.java
@@ -96,7 +96,7 @@ public class GalleryBucketUtils {
 
             // ignore buckets created by Seadroid
             String file = cursor.getString(dataColumnIndex);
-            if (!file.startsWith(DataManager.getExternalRootDirectory()))
+            if (file == null || !file.startsWith(DataManager.getExternalRootDirectory()))
                 buckets.add(b);
         }
         cursor.close();


### PR DESCRIPTION
Apparently, DATA column may be null in the media provider for videos. Not sure why, but this should avoid the crash.

[Due to lack of time, I only compile-tested this patch.]