### PR TITLE
Notify file already exist before uploading

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -174,6 +174,10 @@
     <string name="upload_finished">Upload finished</string>
     <string name="upload_cancelled">Upload cancelled</string>
     <string name="upload_failed">Upload failed</string>
+    <string name="upload_file_exist">File already exist</string>
+    <string name="upload_duplicate_found">An item named \"%s\" already exist in this location.\n Do you want to replace it with the one you\`re moving?</string>
+    <string name="upload_replace_all">Replace All</string>
+    <string name="upload_keep_both">Keep Both</string>
     <string name="days_ago">%d days ago</string>
     <string name="hours_ago">%d hours ago</string>
     <string name="minutes_ago">%d minutes ago</string>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha7'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta6'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Notify user duplicate file is about to upload, user can choose to cancel or proceed.
To check if the file already exist, cache it locally and compare its name before uploading.