### PR TITLE
Storage: Add option to move cache to external SD card on Android 4.4+

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/SeadroidApplication.java
+++ b/app/src/main/java/com/seafile/seadroid2/SeadroidApplication.java
@@ -13,7 +13,7 @@ import com.nostra13.universalimageloader.core.ImageLoader;
 import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
 import com.nostra13.universalimageloader.core.assist.QueueProcessingType;
 import com.seafile.seadroid2.avatar.AuthImageDownloader;
-import com.seafile.seadroid2.data.DataManager;
+import com.seafile.seadroid2.data.StorageManager;
 import com.seafile.seadroid2.gesturelock.AppLockManager;
 
 public class SeadroidApplication extends Application {
@@ -36,7 +36,7 @@ public class SeadroidApplication extends Application {
     
     public static void initImageLoader(Context context) {
         
-        File cacheDir = DataManager.getThumbnailCacheDirectory();
+        File cacheDir = StorageManager.getInstance().getThumbnailsDir();
         // This configuration tuning is custom. You can tune every option, you may tune some of them,
         // or you can create default configuration by
         //  ImageLoaderConfiguration.createDefault(this);

--- a/app/src/main/java/com/seafile/seadroid2/SeafConnection.java
+++ b/app/src/main/java/com/seafile/seadroid2/SeafConnection.java
@@ -476,7 +476,7 @@ public class SeafConnection {
                 };
             }
 
-            File tmp = DataManager.getTempFile(path, oid);
+            File tmp = DataManager.createTempFile();
             // Log.d(DEBUG_TAG, "write to " + tmp.getAbsolutePath());
             if (monitor == null) {
                 req.receive(tmp);

--- a/app/src/main/java/com/seafile/seadroid2/SettingsManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/SettingsManager.java
@@ -45,6 +45,9 @@ public final class SettingsManager {
 
     // Camera upload
     public static final String PKG = "com.seafile.seadroid2";
+
+    public static final String SHARED_PREF_STORAGE_DIR = PKG + ".storageId";
+
     public static final String SHARED_PREF_CAMERA_UPLOAD_REPO_ID = PKG + ".camera.repoid";
     public static final String SHARED_PREF_CAMERA_UPLOAD_REPO_NAME = PKG + ".camera.repoName";
     public static final String SHARED_PREF_CAMERA_UPLOAD_ACCOUNT_EMAIL = PKG + ".camera.account.email";
@@ -66,8 +69,10 @@ public final class SettingsManager {
     public static final String SETTINGS_ABOUT_AUTHOR_KEY = "settings_about_author_key";
 
     // Cache
+    public static final String SETTINGS_CACHE_CATEGORY_KEY = "settings_cache_key";
     public static final String SETTINGS_CACHE_SIZE_KEY = "settings_cache_info_key";
     public static final String SETTINGS_CLEAR_CACHE_KEY = "settings_clear_cache_key";
+    public static final String SETTINGS_CACHE_DIR_KEY = "settings_cache_location_key";
 
     // Sort files
     public static final String SORT_FILES_TYPE = "sort_files_type";
@@ -202,8 +207,12 @@ public final class SettingsManager {
         return sharedPref.getString(SettingsManager.SHARED_PREF_CAMERA_UPLOAD_REPO_ID, null);
     }
 
-    public void delCachesByActSignature(Account account) {
-        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper();
-        dbHelper.delCachesBySignature(account);
+    public int getStorageDir() {
+        return sharedPref.getInt(SHARED_PREF_STORAGE_DIR, Integer.MIN_VALUE);
     }
+
+    public void setStorageDir(int dir) {
+        editor.putInt(SHARED_PREF_STORAGE_DIR, dir).commit();
+    }
+
 }

--- a/app/src/main/java/com/seafile/seadroid2/cameraupload/CameraSyncAdapter.java
+++ b/app/src/main/java/com/seafile/seadroid2/cameraupload/CameraSyncAdapter.java
@@ -21,6 +21,7 @@ import com.google.common.base.Joiner;
 import com.seafile.seadroid2.R;
 import com.seafile.seadroid2.SeafException;
 import com.seafile.seadroid2.SettingsManager;
+import com.seafile.seadroid2.data.StorageManager;
 import com.seafile.seadroid2.account.Account;
 import com.seafile.seadroid2.account.AccountManager;
 import com.seafile.seadroid2.data.DataManager;
@@ -513,7 +514,7 @@ public class CameraSyncAdapter extends AbstractThreadedSyncAdapter {
             }
 
             // Ignore all media by Seafile. We don't want to upload our own cached files.
-            if (file.getAbsolutePath().startsWith(DataManager.getExternalRootDirectory())) {
+            if (file.getAbsolutePath().startsWith(StorageManager.getInstance().getMediaDir().getAbsolutePath())) {
                 // Log.d(DEBUG_TAG, "Skipping media "+file+" because it's part of the Seadroid cache");
                 continue;
             }

--- a/app/src/main/java/com/seafile/seadroid2/cameraupload/GalleryBucketUtils.java
+++ b/app/src/main/java/com/seafile/seadroid2/cameraupload/GalleryBucketUtils.java
@@ -5,7 +5,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.MediaStore;
 
-import com.seafile.seadroid2.data.DataManager;
+import com.seafile.seadroid2.data.StorageManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -96,7 +96,7 @@ public class GalleryBucketUtils {
 
             // ignore buckets created by Seadroid
             String file = cursor.getString(dataColumnIndex);
-            if (file == null || !file.startsWith(DataManager.getExternalRootDirectory()))
+            if (file == null || !file.startsWith(StorageManager.getInstance().getMediaDir().getAbsolutePath()))
                 buckets.add(b);
         }
         cursor.close();
@@ -147,7 +147,7 @@ public class GalleryBucketUtils {
 
             // ignore buckets created by Seadroid
             String file = cursor.getString(dataColumnIndex);
-            if (file == null || !file.startsWith(DataManager.getExternalRootDirectory()))
+            if (file == null || !file.startsWith(StorageManager.getInstance().getMediaDir().getAbsolutePath()))
                 buckets.add(b);
         }
         cursor.close();

--- a/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
@@ -75,7 +75,7 @@ public class DataManager {
      * @throws IOException if the directory could not be created.
      */
     public static File createTempDir() throws IOException {
-        String dirName = "dir-" + UUID.randomUUID() + ".tmp";
+        String dirName = "dir-" + UUID.randomUUID();
         File dir = new File (storageManager.getTempDir(), dirName);
         if (dir.mkdir()) {
             return dir;

--- a/app/src/main/java/com/seafile/seadroid2/data/DatabaseHelper.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/DatabaseHelper.java
@@ -169,7 +169,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         // This database is only a cache for online data, so its upgrade policy is
         // to simply to discard the data and start over
 
-        File dir = new File(DataManager.getExternalRootDirectory());
+        File dir = StorageManager.getInstance().getJsonCacheDir();
         for (File f : dir.listFiles()) {
             if (f.isFile()) {
                 f.delete();
@@ -248,14 +248,11 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 new String[] { item.repoID, item.path });
     }
 
-    /**
-     * delete all cache info under one specific account from database
-     *
-     * @param account
-     */
-    public void delCachesBySignature(Account account) {
-        String signature = account.getSignature();
-        database.delete(FILECACHE_TABLE_NAME, FILECACHE_COLUMN_ACCOUNT + "=?", new String[]{signature});
+    public void delCaches() {
+        database.delete(REPODIR_TABLE_NAME, null, null);
+        database.delete(FILECACHE_TABLE_NAME, null, null);
+        database.delete(DIRENTS_CACHE_TABLE_NAME, null, null);
+        database.delete(STARRED_FILECACHE_TABLE_NAME, null, null);
     }
 
     public List<SeafCachedFile> getFileCacheItems(DataManager dataManager) {

--- a/app/src/main/java/com/seafile/seadroid2/data/StorageManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/StorageManager.java
@@ -388,16 +388,16 @@ public abstract class StorageManager implements MediaScannerConnection.OnScanCom
     }
 
     /**
-     * Store JSON cache files in a subdirectory below the media directory.
+     * Store JSON cache files in private internal cache.
      *
-     * This is currently chosen to be backwards compatible with older Seadroid releases.
-     * TODO: we might want to move this to Context.getCacheDir() for privacy reasons
-     * (so that other apps cannot read it)
+     * This cache directory will contain json files listing the repositories and directory listings.
+     * this can be pretty private (especially the repository listing). So these should not be readable
+     * by other apps. Therefore we save them in internal storage, where only Seadroid has access to.
      *
      * @return base of where to store JSON cache files
      */
     public final File getJsonCacheDir() {
-        File base = getStorageLocation().cachePath;
+        File base = getContext().getCacheDir();
         return getDirectoryCreateIfNeeded(base);
     }
 

--- a/app/src/main/java/com/seafile/seadroid2/data/StorageManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/StorageManager.java
@@ -1,0 +1,517 @@
+package com.seafile.seadroid2.data;
+
+import android.content.Context;
+import android.media.MediaScannerConnection;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.support.v4.os.EnvironmentCompat;
+import android.text.format.Formatter;
+import android.util.Log;
+
+import com.seafile.seadroid2.R;
+import com.seafile.seadroid2.SeadroidApplication;
+import com.seafile.seadroid2.SettingsManager;
+import com.seafile.seadroid2.account.Account;
+import com.seafile.seadroid2.account.AccountManager;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * This class decides where to store Seadroid's data in the file system.
+ *
+ * Up till API 18, there was not much choice. Only CLASSIC_LOCATION did make any sense
+ * to use. Starting with KitKat new options have appeared. API 19+ offers an API to get a list
+ * of possible storage locations, which will include things like SD cards or USB connected flash
+ * drives.
+ *
+ * This StorageManager allows the user to make the choice where to store its data. It remembers
+ * this choice in the SettingsManager.
+ *
+ * This StorageManager also does an auto-selection of the best storage on first use of Seadroid.
+ *
+ * The following data falls into the scope of this StorageManager:
+ *
+ * - Downloaded repository files
+ *     -> Indexed by Gallery
+ *     -> synced server content, might be deleted locally
+ *     -> persistent, as deletion would cause user inconvenience
+ *
+ * - Temp files (e.g. pending for upload, download in progress)
+ *     -> NOT indexed by Gallery
+ *     -> important content, not to be deleted prematurely
+ *     -> only temporary
+ *     -> might be moved to "Downloaded repository files", so should be same mount point
+ *
+ * - Image thumbnails
+ *     -> NOT indexed by Gallery
+ *     -> long term storage
+ *     -> not important content, can be deleted if necessary
+ *
+ * - JSON Cache files
+ *     -> NOT indexed by Gallery
+ *     -> long term storage
+ *     -> not important content, can be deleted if necessary
+ *
+ * This class offers a set of methods to retrieve the base dir for specific types of data.
+ *
+ * Useful links:
+ * - https://developer.android.com/guide/topics/data/data-storage.html
+ */
+public abstract class StorageManager implements MediaScannerConnection.OnScanCompletedListener {
+
+    protected static final String DEBUG_TAG = "StorageManager";
+
+    private static StorageManager instance = null;
+
+    private final Location CLASSIC_LOCATION;
+
+    public StorageManager() {
+        CLASSIC_LOCATION = buildClassicLocation();
+    }
+
+    /**
+     * Fetch instance of the StorageManager
+     * @return
+     */
+    public final static StorageManager getInstance() {
+        if (instance == null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                instance = new StorageManagerLollipop();
+            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                instance = new StorageManagerKitKat();
+            } else {
+                instance = new StorageManagerGingerbread();
+            }
+        }
+        return instance;
+    }
+
+    private Location buildClassicLocation() {
+        Location classic = new Location();
+        classic.id = -1; // Android IDs start at 0. so "-1" is safe for us
+        classic.mediaPath = new File(Environment.getExternalStorageDirectory().getAbsolutePath() + "/Seafile/");
+        classic.cachePath = new File(classic.mediaPath, "cache");
+        fillLocationInfo(classic);
+        return classic;
+    }
+
+    private void fillLocationInfo(Location loc) {
+        loc.available = loc.mediaPath != null && EnvironmentCompat.getStorageState(loc.mediaPath).equals(Environment.MEDIA_MOUNTED);
+
+        String label;
+        // labels "primary/secondary" are as defined by https://possiblemobile.com/2014/03/android-external-storage/
+        if (loc.id <= 0) {
+            label = getContext().getString(R.string.storage_manager_primary_storage);
+        } else {
+            label = getContext().getString(R.string.storage_manager_secondary_storage);
+        }
+        if (loc.available) {
+            loc.description = getContext().getString(R.string.storage_manager_storage_description,
+                            label,
+                            Formatter.formatFileSize(getContext(), getStorageFreeSpace(loc.mediaPath)),
+                            Formatter.formatFileSize(getContext(), getStorageSize(loc.mediaPath)));
+        } else {
+            loc.description = getContext().getString(R.string.storage_manager_storage_description_not_available,
+                            label);
+        }
+    }
+
+    /**
+     * Get the media directories offered by Android.
+     *
+     * @return
+     */
+    protected abstract File[] getSystemMediaDirs();
+
+    /**
+     * Get the cache directories offered by Android.
+     *
+     * @return
+     */
+    protected abstract File[] getSystemCacheDirs();
+
+    /**
+     * Get partition size of the mount point containing dir
+     *
+     * @param dir
+     * @return
+     */
+    protected abstract long getStorageSize(File dir);
+
+    /**
+     * Get free size of the mount point containing dir
+     *
+     * @param dir
+     * @return
+     */
+    protected abstract long getStorageFreeSpace(File dir);
+
+    /**
+     * Allows this device multiple storage locations?
+     * @return
+     */
+    public abstract boolean supportsMultipleStorageLocations();
+
+    /**
+     * Callback when a file has been added/removed by us in the Android Media Store
+     *
+     * @param path
+     * @param uri
+     */
+    public void onScanCompleted(String path, Uri uri) {
+    }
+
+    public final ArrayList<Location> getStorageLocations() {
+        ArrayList<Location> retList = new ArrayList<>();
+
+        int selectedDir = SettingsManager.instance().getStorageDir();
+
+        retList.add(CLASSIC_LOCATION);
+
+        File[] dirs = getSystemMediaDirs();
+        File[] cacheDirs = getSystemCacheDirs();
+        for (int i = 0; i < dirs.length; i++) {
+
+            // omit the mount point where CLASSIC_LOCATION lies (would be duplicate)
+            if (i == 0)
+                continue;
+
+            Location location = new Location();
+            location.id = i;
+            location.mediaPath = dirs[i];
+            location.cachePath = cacheDirs[i];
+            retList.add(location);
+        }
+
+        // add current selection at the end, even if the storage is currently unavailable
+        if (selectedDir != CLASSIC_LOCATION.id && selectedDir >= dirs.length) {
+            Location location = new Location();
+            location.id = selectedDir;
+            location.mediaPath = null;
+            location.cachePath = null;
+            retList.add(location);
+        }
+
+        for (Location loc: retList) {
+            loc.currentSelection = (loc.id == selectedDir);
+            fillLocationInfo(loc); // fill in size & description info
+        }
+
+        return retList;
+    }
+
+    /**
+     * Set the new storage directory.
+     *
+     * This will change the settings and move files from the old to the new location.
+     * Therefore, this method might take a while to finish.
+     *
+     * @param id the ID of the new storage location
+     */
+    public final void setStorageDir(int id) {
+
+        int oldID = SettingsManager.instance().getStorageDir();
+
+        if (oldID == id)
+            return;
+
+        Location newLocation = lookupStorageLocation(id);
+
+        File newMediaDir = newLocation.mediaPath;
+
+        if (newLocation.mediaPath == null || !EnvironmentCompat.getStorageState(newMediaDir).equals(Environment.MEDIA_MOUNTED)) {
+            Log.i(DEBUG_TAG, "Selected storage dir is unavailable! " + newMediaDir);
+            return;
+        }
+
+        Location oldLocation = lookupStorageLocation(oldID);
+        if (oldLocation != null) {
+            AccountManager manager = new AccountManager(getContext());
+
+            try {
+                // move cached files from old location to new location (might take a while)
+
+                for (Account account: manager.getAccountList()) {
+                    DataManager dataManager = new DataManager(account);
+                    File oldAccountDir = new File(dataManager.getAccountDir());
+
+                    if (oldAccountDir.isDirectory()) {
+                        FileUtils.copyDirectoryToDirectory(oldAccountDir, newMediaDir);
+                    }
+                }
+                notifyAndroidGalleryDirectoryChange(FileUtils.listFiles(newMediaDir, null, true));
+
+            } catch (IOException e) {
+                Log.e(DEBUG_TAG, "Could not move cache to new location", e);
+                return;
+            }
+
+            // remove everything in the old cache directories (thumbnails, etc).
+            clearCache();
+        }
+
+        Log.i(DEBUG_TAG, "Setting storage directory to " + newMediaDir);
+        SettingsManager.instance().setStorageDir(id);
+    }
+
+    /**
+     * Decide, which storage to use. This will be called only once,
+     * on first start of Seadroid. After that, it's read from the Settings.
+     *
+     *  -> API 19+
+     *  It selects the media with the most free space in it.
+     *
+     *  -> API 1-18
+     *  On pre-KitKat, only CLASSIC_LOCATION is available. So there is no choice.
+     *
+     * This method does not change the Settings. It just evaluates what the best storage location
+     * might be.
+     *
+     * @return storage ID with the most free space
+    */
+    private Location getPreferredStorage() {
+
+        /* Backwards compatibility on upgrade:
+         * If there is already CLASSIC_LOCATION present on the system, prefer it
+         */
+        if (CLASSIC_LOCATION.mediaPath.exists() && CLASSIC_LOCATION.mediaPath.isDirectory()) {
+
+            return CLASSIC_LOCATION;
+
+        } else {
+
+            // auto-select the location with the most free space available
+
+            Location best = null;
+            for (Location location: getStorageLocations()) {
+                if (!location.available)
+                    continue;
+
+                if (best == null || getStorageFreeSpace(best.mediaPath) < getStorageFreeSpace(location.mediaPath))
+                    best = location;
+            }
+
+            if (best == null)
+                return CLASSIC_LOCATION;
+
+            return best;
+        }
+    }
+
+    /**
+     * Return the base directory for media storage to be used in Seadroid.
+     *
+     * It guaranties to always return a valid directory.
+     * However, this directory might change at runtime, So it should never be cached.
+     *
+     * @return the base directory for media storage to be used in Seadroid.
+     */
+    public final File getMediaDir() {
+        return getDirectoryCreateIfNeeded(getStorageLocation().mediaPath);
+    }
+
+    private Location lookupStorageLocation(int id) {
+        for (Location location: getStorageLocations()) {
+            if (location.id == id)
+                return location;
+        }
+        return null;
+    }
+
+    /**
+     * Return the storage location to be used in Seadroid.
+     *
+     * It guaranties to always return a valid one.
+     *
+     * @return Location info
+     */
+    private Location getStorageLocation() {
+
+        int storageDirID = SettingsManager.instance().getStorageDir();
+        Location storageLocation = lookupStorageLocation(storageDirID);
+
+        // if there is one configured but unavailable, use fallback
+        if (storageDirID >= 0 && !storageLocation.available) {
+            Log.i(DEBUG_TAG, "Configured storage location " + storageDirID + " has become unavailable, falling back.");
+            return CLASSIC_LOCATION;
+        }
+
+        // on first start of Seadroid, no location is configured yet
+        if (storageDirID == Integer.MIN_VALUE) {
+
+            storageLocation = getPreferredStorage();
+
+            Log.i(DEBUG_TAG, "First start of Seadroid, auto-setting storage directory to " + storageLocation.id);
+            SettingsManager.instance().setStorageDir(storageLocation.id);
+        }
+
+        if (storageLocation == null || !storageLocation.available) {
+            Log.i(DEBUG_TAG, "Storage location " + storageLocation.id + " has become unavailable, falling back.");
+            return CLASSIC_LOCATION;
+        }
+
+        // an explicit path is configured
+        return storageLocation;
+    }
+
+    private File getDirectoryCreateIfNeeded(File dir) {
+        if (dir.exists()) {
+            return dir;
+        } else {
+            dir.mkdirs();
+        }
+        return dir;
+    }
+
+    protected final Context getContext() {
+        return SeadroidApplication.getAppContext();
+    }
+
+    /**
+     * Store temp files in a subdirectory below the media directory.
+     *
+     * This should be a subdirectory of getMediaDir() so that temp files
+     * can be efficiently moved into the media storage.
+     *
+     * @return base of where to store temp files
+     */
+    public final File getTempDir() {
+        File base = getMediaDir();
+        File tmpDir = new File(base, "temp");
+        return getDirectoryCreateIfNeeded(tmpDir);
+    }
+
+    /**
+     * Store JSON cache files in a subdirectory below the media directory.
+     *
+     * This is currently chosen to be backwards compatible with older Seadroid releases.
+     * TODO: we might want to move this to Context.getCacheDir() for privacy reasons
+     * (so that other apps cannot read it)
+     *
+     * @return base of where to store JSON cache files
+     */
+    public final File getJsonCacheDir() {
+        File base = getStorageLocation().cachePath;
+        return getDirectoryCreateIfNeeded(base);
+    }
+
+    /**
+     * Store thumbnails in a subdirectory below the Seadroid cache directory.
+     *
+     * @return base of where to store thumbnails
+     */
+    public final File getThumbnailsDir() {
+        File base = getStorageLocation().cachePath;
+        File thumbnailsDir = new File(base, "thumbnails");
+        return getDirectoryCreateIfNeeded(thumbnailsDir);
+    }
+
+    /**
+     * A file was added, changed or removed. Notify the gallery.
+     *
+     * @param file
+     */
+    public final void notifyAndroidGalleryFileChange(File file) {
+        MediaScannerConnection.scanFile(getContext(),
+            new String[]{file.toString()},
+            null,
+            this);
+    }
+
+    /**
+     * A directory was added, changed or removed. Notify the gallery.
+     *
+     * @param fileList
+     */
+    private final void notifyAndroidGalleryDirectoryChange(Collection<File> fileList) {
+
+        int count = 0;
+        String[] list = new String[fileList.size()];
+        for (File f: fileList) {
+            list[count++] = f.getAbsolutePath();
+        }
+
+        MediaScannerConnection.scanFile(getContext(),
+                list, null, this);
+    }
+
+    /**
+     * Deletes full cache
+     * remember to clear cache from database after called this method
+     */
+    public final void clearCache() {
+        Collection<File> fileList = FileUtils.listFiles(getMediaDir(), null, true);
+
+        FileUtils.deleteQuietly(getMediaDir());
+        FileUtils.deleteQuietly(getJsonCacheDir());
+        FileUtils.deleteQuietly(getTempDir());
+        FileUtils.deleteQuietly(getThumbnailsDir());
+
+        notifyAndroidGalleryDirectoryChange(fileList);
+    }
+
+    /**
+     * Deletes cache directory under a specific account<br>
+     * remember to clear cache from database after called this method
+     */
+    public final void clearAccount(Account account) {
+        DataManager dataManager = new DataManager(account);
+
+        File accountDir = new File(dataManager.getAccountDir());
+        Collection<File> fileList = FileUtils.listFiles(accountDir, null, true);
+
+        FileUtils.deleteQuietly(accountDir);
+
+        notifyAndroidGalleryDirectoryChange(fileList);
+    }
+
+    /**
+     * Return space used by Seadroid
+     *
+     * @return
+     */
+    public final long getUsedSpace() {
+        File mediaDir = getMediaDir();
+        File thumbDir = getThumbnailsDir();
+
+        return FileUtils.sizeOfDirectory(mediaDir) + FileUtils.sizeOfDirectory(thumbDir);
+    }
+
+    public static class Location {
+        /**
+         * Our internal ID of this storage.
+         */
+        public int id;
+
+        /**
+         * Base media directory
+         */
+        public File mediaPath;
+
+        /**
+         * Base cache directory
+         */
+        public File cachePath;
+
+        /**
+         * Text description
+         */
+        public String description;
+
+        /**
+         * Is this location available (mounted)?
+         */
+        public boolean available;
+
+        /**
+         * Is this the currently selected location?
+         */
+        public boolean currentSelection;
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/data/StorageManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/StorageManager.java
@@ -331,7 +331,7 @@ public abstract class StorageManager implements MediaScannerConnection.OnScanCom
      *
      * @return Location info
      */
-    private Location getStorageLocation() {
+    public Location getStorageLocation() {
 
         int storageDirID = SettingsManager.instance().getStorageDir();
         Location storageLocation = lookupStorageLocation(storageDirID);

--- a/app/src/main/java/com/seafile/seadroid2/data/StorageManagerGingerbread.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/StorageManagerGingerbread.java
@@ -1,0 +1,38 @@
+package com.seafile.seadroid2.data;
+
+import android.os.StatFs;
+
+import java.io.File;
+
+/**
+ * StorageManager implementation for pre-KitKat devices.
+ */
+public class StorageManagerGingerbread extends StorageManager {
+
+    @Override
+    protected File[] getSystemMediaDirs() {
+        return new File[]{};
+    }
+
+    @Override
+    protected File[] getSystemCacheDirs() {
+        return new File[]{};
+    }
+
+    @Override
+    protected long getStorageSize(File dir) {
+        StatFs stat = new StatFs(dir.getParentFile().getAbsolutePath());
+        return (long)stat.getBlockCount() * stat.getBlockSize();
+    }
+
+    @Override
+    protected long getStorageFreeSpace(File dir) {
+        StatFs stat = new StatFs(dir.getParentFile().getAbsolutePath());
+        return (long)stat.getAvailableBlocks() * stat.getBlockSize();
+    }
+
+    @Override
+    public boolean supportsMultipleStorageLocations() {
+        return false;
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/data/StorageManagerKitKat.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/StorageManagerKitKat.java
@@ -1,0 +1,95 @@
+package com.seafile.seadroid2.data;
+
+import android.annotation.TargetApi;
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.net.Uri;
+import android.os.Build;
+import android.os.StatFs;
+import android.provider.MediaStore;
+import android.util.Log;
+
+import com.seafile.seadroid2.SeadroidApplication;
+import com.seafile.seadroid2.util.Utils;
+
+import java.io.File;
+
+
+/**
+ * StorageManager implementation for KitKat devices.
+ */
+@TargetApi(Build.VERSION_CODES.KITKAT)
+public class StorageManagerKitKat extends StorageManager {
+
+    @Override
+    protected File[] getSystemMediaDirs() {
+        /**
+         * KitKat does offer media directories on every storage medium.
+         * So this is a good API to store our data in.
+         *
+         * Unfortunately, KitKat has a bug, that files in this directory
+         * won't be indexed by the gallery. This bug can be workarounded
+         * however, which we do in Utils.notifyAndroidGalleryFileChange()
+         */
+        return getContext().getExternalFilesDirs(null);
+    }
+
+    @Override
+    protected File[] getSystemCacheDirs() {
+        return getContext().getExternalCacheDirs();
+    }
+
+    @Override
+    protected long getStorageSize(File dir) {
+        StatFs stat = new StatFs(dir.getParentFile().getAbsolutePath());
+        return stat.getTotalBytes();
+    }
+
+    @Override
+    protected long getStorageFreeSpace(File dir) {
+        StatFs stat = new StatFs(dir.getParentFile().getAbsolutePath());
+        return stat.getAvailableBytes();
+    }
+
+    @Override
+    public boolean supportsMultipleStorageLocations() {
+        return true;
+    }
+
+    @Override
+    public void onScanCompleted(String path, Uri uri) {
+        super.onScanCompleted(path, uri);
+
+        /*
+         * According to the Android API, media files stored in Context.getExternalFilesDir[s]()
+         * should be indexed by the Media Scanner.
+         *
+         * Unfortunately, the Android framework has a bug there: The files are indexed into the Media
+         * Store, but not as "photos" or "videos", but as generic "files". As such they won't show
+         * up in the Android Gallery app.
+         *
+         * https://code.google.com/p/android/issues/detail?id=68056#c1 explains this
+         * and suggests a workaround. The following code is an implementation of that workaround.
+         *
+         * Starting with API 21, Android has extended its API with Context.getExternalMediaDirs(),
+         * which works as advertised. So this workaround is only necessary on API levels 19 and 20.
+         */
+        if (uri != null && uri.getPath().startsWith("/external/file")) {
+            ContentResolver contentResolver = SeadroidApplication.getAppContext().getContentResolver();
+            // if a files has just been added as a generic "file", fix the MediaStore and change the
+            // file type to image or video.
+
+            ContentValues v = new ContentValues();
+            String mimeType = Utils.getFileMimeType(path);
+
+            if (mimeType.startsWith("image/")) {
+                v.put(MediaStore.Files.FileColumns.MEDIA_TYPE, MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE);
+            } else if (mimeType.startsWith("video/")) {
+                v.put(MediaStore.Files.FileColumns.MEDIA_TYPE, MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO);
+            }
+
+            int rows = contentResolver.update(uri, v, null, null);
+            Log.d(DEBUG_TAG, "-> rows=" + rows);
+        }
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/data/StorageManagerLollipop.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/StorageManagerLollipop.java
@@ -1,0 +1,45 @@
+package com.seafile.seadroid2.data;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.os.StatFs;
+
+import java.io.File;
+
+/**
+ * StorageManager implementation for Lollipop or newer devices.
+ */
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+public class StorageManagerLollipop extends StorageManager {
+
+    @Override
+    protected File[] getSystemMediaDirs() {
+        /*
+         * Since Lollipop there is a proper media directory on every storage device.
+         * It is indexed by the gallery and the best place for Seafile to store cached files.
+         */
+        return getContext().getExternalMediaDirs();
+    }
+
+    @Override
+    protected File[] getSystemCacheDirs() {
+        return getContext().getExternalCacheDirs();
+    }
+
+    @Override
+    protected long getStorageSize(File dir) {
+        StatFs stat = new StatFs(dir.getParentFile().getAbsolutePath());
+        return stat.getTotalBytes();
+    }
+
+    @Override
+    protected long getStorageFreeSpace(File dir) {
+        StatFs stat = new StatFs(dir.getParentFile().getAbsolutePath());
+        return stat.getAvailableBytes();
+    }
+
+    @Override
+    public boolean supportsMultipleStorageLocations() {
+        return true;
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/gallery/ImageLoader.java
+++ b/app/src/main/java/com/seafile/seadroid2/gallery/ImageLoader.java
@@ -3,6 +3,7 @@ package com.seafile.seadroid2.gallery;
 import android.content.ContentResolver;
 import android.graphics.Bitmap;
 import android.os.Handler;
+import android.util.Log;
 
 import java.util.ArrayList;
 
@@ -133,6 +134,12 @@ public class ImageLoader {
         mDone = false;
         Thread t = new Thread(new WorkerThread());
         t.setName("image-loader");
+        t.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread thread, Throwable ex) {
+                Log.e(TAG, "Uncaught exception", ex);
+            }
+        });
         mDecodeThread = t;
         t.start();
     }

--- a/app/src/main/java/com/seafile/seadroid2/monitor/AutoUpdateManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/monitor/AutoUpdateManager.java
@@ -36,6 +36,12 @@ public class AutoUpdateManager implements Runnable, CachedFileChangedListener {
         this.txService = txService;
         running = true;
         thread = new Thread(this);
+        thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread thread, Throwable ex) {
+                Log.e(DEBUG_TAG, "Uncaught exception", ex);
+            }
+        });
         thread.start();
     }
 
@@ -117,7 +123,7 @@ public class AutoUpdateManager implements Runnable, CachedFileChangedListener {
         }
 
         if (exist) {
-            ConcurrentAsyncTask.execute(new Runnable() {
+            ConcurrentAsyncTask.submit(new Runnable() {
                 @Override
                 public void run() {
                     db.removeAutoUpdateInfo(info);

--- a/app/src/main/java/com/seafile/seadroid2/monitor/FileMonitorService.java
+++ b/app/src/main/java/com/seafile/seadroid2/monitor/FileMonitorService.java
@@ -35,7 +35,7 @@ public class FileMonitorService extends Service {
             monitor = new SeafileMonitor(updateMgr);
         }
 
-        ConcurrentAsyncTask.execute(new Runnable() {
+        ConcurrentAsyncTask.submit(new Runnable() {
             @Override
             public void run() {
                 monitor.monitorAllAccounts();

--- a/app/src/main/java/com/seafile/seadroid2/ssl/CertsManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/ssl/CertsManager.java
@@ -40,7 +40,7 @@ public final class CertsManager {
         cachedCerts.put(account, cert);
 
         if (rememberChoice) {
-            ConcurrentAsyncTask.execute(new Runnable() {
+            ConcurrentAsyncTask.submit(new Runnable() {
                 @Override
                 public void run() {
                     db.saveCertificate(account.server, cert);

--- a/app/src/main/java/com/seafile/seadroid2/ui/activity/ShareToSeafileActivity.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/activity/ShareToSeafileActivity.java
@@ -88,16 +88,12 @@ public class ShareToSeafileActivity extends BaseActivity {
 
             List<File> fileList = new ArrayList<File>();
             for (Uri uri: uriList) {
-                File tempDir = new File(DataManager.getExternalTempDirectory(), "shared_temp" + "/" + "shared-"+System.currentTimeMillis());
-                File tempFile = new File(tempDir, Utils.getFilenamefromUri(ShareToSeafileActivity.this, uri));
-
-                // Log.d(DEBUG_TAG, "Uploading file from uri: " + uri);
-
                 InputStream in = null;
                 OutputStream out = null;
 
                 try {
-                    tempDir.mkdirs();
+                    File tempDir = DataManager.createTempDir();
+                    File tempFile = new File(tempDir, Utils.getFilenamefromUri(ShareToSeafileActivity.this, uri));
 
                     if (!tempFile.createNewFile()) {
                         throw new RuntimeException("could not create temporary file");
@@ -107,17 +103,16 @@ public class ShareToSeafileActivity extends BaseActivity {
                     out = new FileOutputStream(tempFile);
                     IOUtils.copy(in, out);
 
+                    fileList.add(tempFile);
+
                 } catch (IOException e) {
                     Log.e(DEBUG_TAG, "Could not open requested document", e);
-                    tempFile = null;
                 } catch (RuntimeException e) {
                     Log.e(DEBUG_TAG, "Could not open requested document", e);
-                    tempFile = null;
                 } finally {
                     IOUtils.closeQuietly(in);
                     IOUtils.closeQuietly(out);
                 }
-                fileList.add(tempFile);
             }
             return fileList.toArray(new File[]{});
         }

--- a/app/src/main/java/com/seafile/seadroid2/ui/dialog/ClearCacheTaskDialog.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/dialog/ClearCacheTaskDialog.java
@@ -1,87 +1,28 @@
 package com.seafile.seadroid2.ui.dialog;
 
-import java.io.IOException;
-
 import android.app.Dialog;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 
 import com.seafile.seadroid2.R;
-import com.seafile.seadroid2.SettingsManager;
-import com.seafile.seadroid2.account.Account;
-import com.seafile.seadroid2.util.Utils;
+import com.seafile.seadroid2.data.DatabaseHelper;
+import com.seafile.seadroid2.data.StorageManager;
 
 class ClearCacheTask extends TaskDialog.Task {
-    private Account account;
-    private String filesDir;
-    private String cacheDir;
-    private String tempDir;
-    private String thumbDir;
-    SettingsManager settingsMgr;
-
-    public ClearCacheTask(Account account, String filesDir, String cacheDir, String tempDir, String thumbDir, SettingsManager settingsManager) {
-        this.account = account;
-        this.filesDir = filesDir;
-        this.cacheDir = cacheDir;
-        this.tempDir = tempDir;
-        this.thumbDir = thumbDir;
-        this.settingsMgr = settingsManager;
-    }
 
     @Override
     protected void runTask() {
-        try {
-            // clear cached files
-            Utils.clearCache(filesDir);
+        StorageManager storageManager = StorageManager.getInstance();
+        storageManager.clearCache();
 
-            // clear cached repo data
-            Utils.clearCache(cacheDir);
-
-            // clear temp files
-            Utils.clearCache(tempDir);
-
-            // clear thumb files
-            Utils.clearCache(thumbDir);
-
-            // clear cached data from database
-            settingsMgr.delCachesByActSignature(account);
-
-            // clear WebView data
-
-            // clear editor cache
-
-        } catch (IOException e) {
-            e.printStackTrace();
-            // delete cache failed
-            // TODO notify user
-        }
+        // clear cached data from database
+        DatabaseHelper dbHelper = DatabaseHelper.getDatabaseHelper();
+        dbHelper.delCaches();
     }
 }
 
 public class ClearCacheTaskDialog extends TaskDialog {
-    private String filesDir;
-    private String cacheDir;
-    private String tempDir;
-    private String thumbDir;
-    private Account account;
-    SettingsManager settingsMgr;
-
-    public void init(Account account, String filesDir, String cacheDir, String tempDir, String thumbDir) {
-        this.account = account;
-        this.filesDir = filesDir;
-        this.cacheDir = cacheDir;
-        this.tempDir = tempDir;
-        this.thumbDir = thumbDir;
-    }
-
-    private SettingsManager getSettingsManager() {
-        if (settingsMgr == null) {
-            settingsMgr = SettingsManager.instance();
-        }
-        return settingsMgr;
-    }
-
     @Override
     protected View createDialogContentView(LayoutInflater inflater, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.dialog_delete_cache, null);
@@ -95,7 +36,7 @@ public class ClearCacheTaskDialog extends TaskDialog {
 
     @Override
     protected ClearCacheTask prepareTask() {
-        ClearCacheTask task = new ClearCacheTask(account, filesDir, cacheDir, tempDir, thumbDir, getSettingsManager());
+        ClearCacheTask task = new ClearCacheTask();
         return task;
     }
 }

--- a/app/src/main/java/com/seafile/seadroid2/ui/dialog/SwitchStorageTaskDialog.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/dialog/SwitchStorageTaskDialog.java
@@ -1,0 +1,126 @@
+package com.seafile.seadroid2.ui.dialog;
+
+import android.app.Dialog;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
+
+import com.seafile.seadroid2.R;
+import com.seafile.seadroid2.SeadroidApplication;
+import com.seafile.seadroid2.account.Account;
+import com.seafile.seadroid2.cameraupload.CameraUploadManager;
+import com.seafile.seadroid2.data.StorageManager;
+import com.seafile.seadroid2.transfer.TransferService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class SwitchStorageTask extends TaskDialog.Task {
+
+    private static final String DEBUG_TAG = "SwitchStorageTask";
+
+    private TransferService txService;
+    private StorageManager.Location location;
+
+    SwitchStorageTask(StorageManager.Location loc) {
+        location = loc;
+        Intent bIntent = new Intent(SeadroidApplication.getAppContext(), TransferService.class);
+        SeadroidApplication.getAppContext().bindService(bIntent, mConnection, Context.BIND_AUTO_CREATE);
+    }
+
+    private ServiceConnection mConnection = new ServiceConnection() {
+        @Override
+        public void onServiceConnected(ComponentName className, IBinder service) {
+            TransferService.TransferBinder binder = (TransferService.TransferBinder) service;
+            txService = binder.getService();
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName arg0) {
+            txService = null;
+        }
+    };
+
+    @Override
+    protected void runTask() {
+        Context context = SeadroidApplication.getAppContext();
+
+        CameraUploadManager camera = new CameraUploadManager(context);
+        Account camAccount = camera.getCameraAccount();
+        if (camera.isCameraUploadEnabled()) {
+            Log.d(DEBUG_TAG, "Temporarily disable camera upload");
+            camera.disableCameraUpload();
+        }
+
+        Log.d(DEBUG_TAG, "Cancel all TransferService tasks");
+        txService.cancelAllUploadTasks();
+        txService.cancellAllDownloadTasks();
+
+        Log.i(DEBUG_TAG, "Switching storage to " + location.description);
+        StorageManager.getInstance().setStorageDir(location.id);
+
+        if (camAccount != null) {
+            Log.d(DEBUG_TAG, "Reenable camera upload");
+            camera.setCameraAccount(camAccount);
+        }
+    }
+}
+
+public class SwitchStorageTaskDialog extends TaskDialog {
+    RadioGroup group;
+    List<RadioButton> buttonList = new ArrayList<>();
+    int currentLocationId = -1;
+
+
+    @Override
+    protected View createDialogContentView(LayoutInflater inflater, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.dialog_switch_storage, null);
+        group = (RadioGroup) view.findViewById(R.id.storage_options);
+
+        ArrayList<StorageManager.Location> options = StorageManager.getInstance().getStorageLocations();
+
+        for (StorageManager.Location location: options) {
+            RadioButton b = new RadioButton(getContext());
+            b.setText(location.description);
+            b.setTag(location);
+            b.setEnabled(location.available);
+            group.addView(b);
+            buttonList.add(b);
+
+            if (location.currentSelection)
+                currentLocationId = b.getId();
+
+        }
+        group.check(currentLocationId);
+
+        return view;
+    }
+
+    @Override
+    protected void onDialogCreated(Dialog dialog) {
+        dialog.setTitle(getResources().getString(R.string.settings_cache_location_title));
+    }
+
+    @Override
+    protected Task prepareTask() {
+        SwitchStorageTask task = null;
+
+        int selectedId = group.getCheckedRadioButtonId();
+        for (RadioButton b: buttonList) {
+            if (b.getId() == selectedId) {
+                StorageManager.Location location = (StorageManager.Location) b.getTag();
+                task = new SwitchStorageTask(location);
+                break;
+            }
+        }
+        return task;
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/ui/dialog/SwitchStorageTaskDialog.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/dialog/SwitchStorageTaskDialog.java
@@ -60,9 +60,11 @@ class SwitchStorageTask extends TaskDialog.Task {
             camera.disableCameraUpload();
         }
 
-        Log.d(DEBUG_TAG, "Cancel all TransferService tasks");
-        txService.cancelAllUploadTasks();
-        txService.cancellAllDownloadTasks();
+        if (txService != null) {
+            Log.d(DEBUG_TAG, "Cancel all TransferService tasks");
+            txService.cancelAllUploadTasks();
+            txService.cancellAllDownloadTasks();
+        }
 
         Log.i(DEBUG_TAG, "Switching storage to " + location.description);
         StorageManager.getInstance().setStorageDir(location.id);

--- a/app/src/main/java/com/seafile/seadroid2/ui/dialog/TaskDialog.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/dialog/TaskDialog.java
@@ -337,6 +337,10 @@ public abstract class TaskDialog extends DialogFragment {
         }
     }
 
+    protected void disableCancel() {
+        cancelButton.setEnabled(false);
+    }
+
     protected void enableInput() {
         if (hasOkButton()) {
             okButton.setEnabled(true);

--- a/app/src/main/java/com/seafile/seadroid2/util/ConcurrentAsyncTask.java
+++ b/app/src/main/java/com/seafile/seadroid2/util/ConcurrentAsyncTask.java
@@ -2,6 +2,21 @@ package com.seafile.seadroid2.util;
 
 import android.os.AsyncTask;
 import android.os.Build;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Make sure an AsyncTask is executed in parallel across different version of
@@ -9,31 +24,73 @@ import android.os.Build;
  * @see asynctask executing tasks serially or concurrently {@link http://www.jayway.com/2012/11/28/is-androids-asynctask-executing-tasks-serially-or-concurrently/}
  */
 public class ConcurrentAsyncTask {
+    private static final String DEBUG_TAG = "ConcurrentAsyncTask";
+
+    /**
+     * We extend ThreadPoolExecutor to log exceptions
+     */
+    private static class SeadroidThreadPoolExecutor extends ThreadPoolExecutor {
+
+        /* Copied over from AsyncTask */
+        private static final int CPU_COUNT = Runtime.getRuntime().availableProcessors();
+        private static final int CORE_POOL_SIZE = CPU_COUNT + 1;
+        private static final int MAXIMUM_POOL_SIZE = CPU_COUNT * 2 + 1;
+        private static final int KEEP_ALIVE = 1;
+        private static final BlockingQueue<Runnable> sPoolWorkQueue = new LinkedBlockingQueue(128);
+
+        private static final ThreadFactory sThreadFactory = new ThreadFactory() {
+            private final AtomicInteger mCount = new AtomicInteger(1);
+
+            public Thread newThread(Runnable r) {
+                return new Thread(r, "SeadroidAsyncTask #" + mCount.getAndIncrement());
+            }
+        };
+
+        public SeadroidThreadPoolExecutor() {
+            super(CORE_POOL_SIZE, MAXIMUM_POOL_SIZE, KEEP_ALIVE,
+                    TimeUnit.SECONDS, sPoolWorkQueue, sThreadFactory);
+        }
+
+        @Override
+        protected void afterExecute(Runnable r, Throwable t) {
+            super.afterExecute(r, t);
+
+            // some exceptions are stored inside the Future, extract them
+            // See ThreadPoolExecutor.afterExecute() javadoc for an explanation
+            if (t == null && r instanceof Future<?>) {
+                try {
+                    Object result = ((Future<?>) r).get();
+                } catch (CancellationException ce) {
+                    t = ce;
+                } catch (ExecutionException ee) {
+                    t = ee.getCause();
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt(); // ignore/reset
+                }
+            }
+
+            if (t != null)
+                Log.e(DEBUG_TAG, "Uncaught exception in thread pool", t);
+        }
+    }
+
+    private static final ThreadPoolExecutor threadPoolExecutor = new SeadroidThreadPoolExecutor();
+
     public static <T> void execute(AsyncTask<T, ?, ?> task, T...args) {
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.HONEYCOMB_MR1) {
             task.execute(args);
         } else {
-            task.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, args);
+            task.executeOnExecutor(threadPoolExecutor, args);
         }
     }
 
-    public static void execute(Runnable runnable) {
-        execute(new SimpleAsyncTask(runnable));
+    @NonNull
+    public static Future<?> submit(Runnable runnable) {
+        return threadPoolExecutor.submit(runnable);
     }
 
-    private static class SimpleAsyncTask extends AsyncTask<Void, Void, Void> {
-        Runnable runnable;
-        public SimpleAsyncTask(Runnable runnable) {
-            this.runnable = runnable;
-        }
-
-        public Void doInBackground(Void... args) {
-            try {
-                runnable.run();
-            } catch(Exception e) {
-                // ignore
-            }
-            return null;
-        }
+    @NonNull
+    public static <T> Future<T> submit(Callable<T> task) {
+        return threadPoolExecutor.submit(task);
     }
 }

--- a/app/src/main/java/com/seafile/seadroid2/util/Utils.java
+++ b/app/src/main/java/com/seafile/seadroid2/util/Utils.java
@@ -70,8 +70,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.TreeMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class Utils {
     public static final String MIME_APPLICATION_OCTET_STREAM = "application/octet-stream";
@@ -601,63 +599,6 @@ public class Utils {
         options.inJustDecodeBounds = false;
         // return BitmapFactory.decodeResource(res, resId, options);
         return BitmapFactory.decodeStream(stream, null, options);
-    }
-
-    /**
-     * Deletes cache directory under a specific account<br>
-     * remember to clear cache from database after called this method
-     *
-     * @param dirPath
-     * @throws IOException
-     */
-    public static void clearCache(String dirPath) throws IOException {
-        // clear all cached files inside of the directory, the directory itself included
-        File cacheDir = new File(dirPath);
-        // FileUtils.deleteDirectory(cacheDir);
-        deleteRecursive(cacheDir);
-
-    }
-
-    private  static void deleteRecursive(File fileOrDirectory) {
-
-        if (fileOrDirectory.isDirectory())
-            for (File child : fileOrDirectory.listFiles())
-                deleteRecursive(child);
-
-        final File renamedFile = new File(fileOrDirectory.getAbsolutePath() + System.currentTimeMillis());
-        fileOrDirectory.renameTo(renamedFile);
-        renamedFile.delete();
-
-        // notify Android Gallery that this file is gone
-        notifyAndroidGalleryFileChange(fileOrDirectory);
-    }
-
-    public static void notifyAndroidGalleryFileChange(File file) {
-        Intent intent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE, Uri.fromFile(file));
-        SeadroidApplication.getAppContext().sendBroadcast(intent);
-    }
-
-    /**
-     * Returns total size of files in bytes of the directory.
-     *
-     * @param dirPath
-     * @return
-     */
-    public static long getDirSize(File dirPath) {
-        long totalSize = 0l;
-
-        if (!dirPath.isDirectory())
-            return 0l;
-
-        File[] files = dirPath.listFiles();
-        for (File file : files) {
-            if (file.isFile()) {
-                totalSize += file.length();
-            } else
-                totalSize += getDirSize(file);
-        }
-
-        return totalSize;
     }
 
     public static String assembleUserName(String email, String server) {

--- a/app/src/main/res/layout/bg_settings_section_cache.xml
+++ b/app/src/main/res/layout/bg_settings_section_cache.xml
@@ -10,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:textColor="@color/fancy_orange"
-        android:text="@string/settings_advance_feature_title"
+        android:text="@string/settings_storage_title"
         android:textAllCaps="true"
         android:gravity="center_vertical"/>
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_switch_storage.xml
+++ b/app/src/main/res/layout/dialog_switch_storage.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingBottom="15dp"
+    android:paddingLeft="10dp"
+    android:paddingRight="10dp"
+    android:paddingTop="10dp" >
+
+    <RadioGroup
+        android:id="@+id/storage_options"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+    </RadioGroup>
+
+    <TextView
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textSize="@dimen/dialog_error_txt_size"
+        android:layout_marginLeft="@dimen/margin_big"
+        android:text="@string/dialog_switch_storage_info_text"
+        />
+
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -443,7 +443,7 @@ Zum Aktualisieren einmal antippen</string>
   <string name="settings_storage_title">ZWISCHENSPEICHER</string>
   <string name="storage_manager_primary_storage">Primärer Speicher</string>
   <string name="storage_manager_secondary_storage">Sekundärer Speicher</string>
-  <string name="storage_manager_storage_description">%1$s (%2$s/%3$s frei)</string>
+  <string name="storage_manager_storage_description">%1$s (%2$s von %3$s frei)</string>
   <string name="storage_manager_storage_description_not_available">%1$s (nicht verfügbar)</string>
   <string name="settings_advance_feature_title"></string>
   <string name="dialog_switch_storage_info_text">Vorhandene Dateien werden zum neuen Ort verschoben. Dies kann etwas dauern.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -339,7 +339,6 @@ Zum Aktualisieren einmal antippen</string>
         <h5>Copyright ©2013-2015 Seafile Ltd.</h5>
         ]]>
     </string>
-  <string name="settings_advance_feature_title">ERWEITERTE FUNKTIONEN</string>
   <string name="settings_cache_title">Größe des Zwischenspeichers</string>
   <string name="settings_clear_cache_title">Zwischenspeicher löschen</string>
   <string name="settings_clear_cache_hint">Möchten Sie den Zwischenspeicher wirklich löschen?</string>
@@ -440,6 +439,14 @@ Zum Aktualisieren einmal antippen</string>
   <string name="overwrite_existing_file_exist">Die Datei ist schon vorhanden</string>
   <!--Action Mode-->
   <string name="action_mode_no_items_selected">Es wurden keine Elemente ausgewählt</string>
+  <string name="settings_cache_location_title">Ort für den Zwischenspeicher wählen</string>
+  <string name="settings_storage_title">ZWISCHENSPEICHER</string>
+  <string name="storage_manager_primary_storage">Primärer Speicher</string>
+  <string name="storage_manager_secondary_storage">Sekundärer Speicher</string>
+  <string name="storage_manager_storage_description">%1$s (%2$s/%3$s frei)</string>
+  <string name="storage_manager_storage_description_not_available">%1$s (nicht verfügbar)</string>
+  <string name="settings_advance_feature_title"></string>
+  <string name="dialog_switch_storage_info_text">Vorhandene Dateien werden zum neuen Ort verschoben. Dies kann etwas dauern.</string>
   <!--Accessibility description for navigation drawer-->
   <!--permission-->
   <string name="permission_read_exteral_storage_rationale">Um Dateien zu bearbeiten bitte Speicherrechte erteilen.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -362,7 +362,7 @@
     <string name="dialog_switch_storage_info_text">Existing files will be moved to the new storage. This might take a while.</string>
     <string name="storage_manager_primary_storage">Primary storage</string>
     <string name="storage_manager_secondary_storage">Secondary storage</string>
-    <string name="storage_manager_storage_description">%1$s (%2$s/%3$s free)</string>
+    <string name="storage_manager_storage_description">%1$s (%2$s free/%3$s total)</string>
     <string name="storage_manager_storage_description_not_available">%1$s (unavailable)</string>
 
     <!-- pull to refresh -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -350,13 +350,20 @@
         ]]>
     </string>
 
-    <string name="settings_advance_feature_title">ADVANCED FEATURE</string>    
+    <string name="settings_storage_title">CACHE STORAGE</string>
     <string name="settings_cache_title">Cache size</string>
     <string name="settings_clear_cache_title">Clear cache</string>
     <string name="settings_clear_cache_hint">Do you want to clear cache?</string>
     <string name="settings_clear_cache_success">Cache cleared successfully</string>
     <string name="settings_clear_cache_failed">Cache cleared failed</string>
     <string name="settings_cache_empty">0 KB</string>
+
+    <string name="settings_cache_location_title">Cache storage location</string>
+    <string name="dialog_switch_storage_info_text">Existing files will be moved to the new storage. This might take a while.</string>
+    <string name="storage_manager_primary_storage">Primary storage</string>
+    <string name="storage_manager_secondary_storage">Secondary storage</string>
+    <string name="storage_manager_storage_description">%1$s (%2$s/%3$s free)</string>
+    <string name="storage_manager_storage_description_not_available">%1$s (unavailable)</string>
 
     <!-- pull to refresh -->
     <string name="pull_to_refresh_pull_label">Pull to refresh&#8230;</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -87,6 +87,22 @@
         </PreferenceScreen>
 
     </PreferenceCategory>
+    
+    <PreferenceCategory android:title="@string/settings_storage_title"
+        android:key="settings_cache_key"
+        android:layout="@layout/bg_settings_section_cache">
+        <Preference
+            android:key="settings_cache_info_key"
+            android:enabled="false"
+            android:title="@string/settings_cache_title" />
+        <Preference
+            android:key="settings_cache_location_key"
+            android:title="@string/settings_cache_location_title"/>
+        <Preference
+            android:key="settings_clear_cache_key"
+            android:title="@string/settings_clear_cache_title" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/settings_about_title"
         android:layout="@layout/bg_settings_section_about">
         <Preference
@@ -96,16 +112,5 @@
         <Preference
                 android:key="settings_about_author_key"
                 android:title="@string/settings_about_author_title" />
-    </PreferenceCategory>
-
-    <PreferenceCategory android:title="@string/settings_advance_feature_title"
-        android:layout="@layout/bg_settings_section_advanced">
-        <Preference
-            android:key="settings_cache_info_key"
-            android:enabled="false"
-            android:title="@string/settings_cache_title" />
-        <Preference
-            android:key="settings_clear_cache_key"
-            android:title="@string/settings_clear_cache_title" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
There are currently two methods to use an SD card with Seadroid (on some devices):

* On Android 6.0, you can "adopt" an SD card for all data storage.
* Older devices placed all app data ("External Storage") on the external SD card by design (don't know if this still done today on any device, but the Android framework still allows it)

This patchset adds a third option. It allows Seadroid to use an SD card on any device running Android 4.4 or newer. It adds an option to the Seadroid settings menu to select the storage location. On upgrade from 2.0.5, the internal storage will continue to be used. On fresh installs, the location with the most free space is selected.

This addresses issue #484 . Please see the individual patches for more details. Patch 3/3 is optional.

I've tested this patchset on
* an Samsung Galaxy Tab S running 5.1
* the Emulator running 6.0
* an older Galaxy Nexus running 4.3

I did not test it on any Android 4.4 device, because I don't have any (and the Emulator is no help). As this patchset contains a code path that is only executed on KitKat (API 19 and 20), it would be a good idea for someone to test this patchset on an KitKat device with an external SD card.

References (since Android storage can be a bit confusing):
* https://developer.android.com/guide/topics/data/data-storage.html#filesExternal
* https://commonsware.com/blog/2014/04/08/storage-situation-external-storage.html
* https://commonsware.com/blog/2014/04/09/storage-situation-removable-storage.html