### PR TITLE
SettingsFragment: Disable camera upload when sync globally disabled

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/fragment/SettingsFragment.java
@@ -297,9 +297,11 @@ public class SettingsFragment extends CustomPreferenceFragment {
         // if the user has globally disabled data sync, we cannot to camera upload
         if (!ContentResolver.getMasterSyncAutomatically()) {
             findPreference(SettingsManager.CAMERA_UPLOAD_SWITCH_KEY).setEnabled(false);
+            ((CheckBoxPreference)findPreference(SettingsManager.CAMERA_UPLOAD_SWITCH_KEY)).setSummaryOff(R.string.settings_camera_upload_service_master_off);
             cameraManager.disableCameraUpload();
         } else {
             findPreference(SettingsManager.CAMERA_UPLOAD_SWITCH_KEY).setEnabled(true);
+            ((CheckBoxPreference)findPreference(SettingsManager.CAMERA_UPLOAD_SWITCH_KEY)).setSummaryOff(R.string.settings_camera_upload_service_stopped);
         }
 
         Account camAccount = cameraManager.getCameraAccount();

--- a/app/src/main/java/com/seafile/seadroid2/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/fragment/SettingsFragment.java
@@ -2,6 +2,7 @@ package com.seafile.seadroid2.ui.fragment;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.ContentResolver;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager.NameNotFoundException;
@@ -280,9 +281,6 @@ public class SettingsFragment extends CustomPreferenceFragment {
             }
         });
 
-        // Cache size
-        calculateCacheSize();
-
         // Clear cache
         findPreference(SettingsManager.SETTINGS_CLEAR_CACHE_KEY).setOnPreferenceClickListener(new OnPreferenceClickListener() {
             @Override
@@ -295,6 +293,15 @@ public class SettingsFragment extends CustomPreferenceFragment {
     }
 
     private void refreshCameraUploadView() {
+
+        // if the user has globally disabled data sync, we cannot to camera upload
+        if (!ContentResolver.getMasterSyncAutomatically()) {
+            findPreference(SettingsManager.CAMERA_UPLOAD_SWITCH_KEY).setEnabled(false);
+            cameraManager.disableCameraUpload();
+        } else {
+            findPreference(SettingsManager.CAMERA_UPLOAD_SWITCH_KEY).setEnabled(true);
+        }
+
         Account camAccount = cameraManager.getCameraAccount();
         if (camAccount != null && settingsMgr.getCameraUploadRepoName() != null) {
             cUploadRepoPref.setSummary(camAccount.getSignature()
@@ -364,6 +371,15 @@ public class SettingsFragment extends CustomPreferenceFragment {
             }
         });
         dialog.show(getFragmentManager(), "DialogFragment");
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+
+        Log.d(DEBUG_TAG, "onResume()");
+        refreshCameraUploadView();
+        calculateCacheSize();
     }
 
     @Override

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -272,6 +272,7 @@ Zum Aktualisieren einmal antippen</string>
   <string name="settings_camera_upload_info_title">Kamerafoto hochladen</string>
   <string name="settings_camera_upload_service_started">Upload-Dienst gestartet</string>
   <string name="settings_camera_upload_service_stopped">Upload-Dienst gestoppt</string>
+  <string name="settings_camera_upload_service_master_off">Datensync global in Android deaktiviert</string>
   <string name="settings_camera_upload_allow_data_plan">Mobilfunknetz erlauben</string>
   <string name="settings_camera_upload_allow_videos">Videos hochladen</string>
   <string name="settings_camera_upload_default_wifi">Standardmäßig nur WLAN-Verbindungen verwenden</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -279,6 +279,7 @@
     <string name="settings_camera_upload_info_title">Camera Photo Upload</string>
     <string name="settings_camera_upload_service_started">Upload service started</string>
     <string name="settings_camera_upload_service_stopped">Upload service stopped</string>
+    <string name="settings_camera_upload_service_master_off">Data auto-sync disabled globally in Android</string>
     <string name="settings_camera_upload_allow_data_plan">Allow Data Plan</string>
     <string name="settings_camera_upload_allow_videos">Allow Videos Upload</string>
     <string name="settings_camera_upload_default_wifi">Use Wi-Fi only by default</string>


### PR DESCRIPTION
- The user can globally disable all sync in Android (via Settings -> Accounts -> Sync Automatically).
In that case, our camera upload will no longer work. To avoid user confusion, we should check for
that and gray out the camera upload entries in the SettingsFragment.

- Also add onResume() to refresh the fragment when necessary.