### PR TITLE
SeafileProvider: fix possible NPE

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
+++ b/app/src/main/java/com/seafile/seadroid2/provider/SeafileProvider.java
@@ -228,7 +228,7 @@ public class SeafileProvider extends DocumentsProvider {
             SeafRepo repo = dm.getCachedRepoByID(repoId);
 
             // encrypted repos are not supported (we can't ask the user for the passphrase)
-            if (repo.encrypted) {
+            if (repo == null || repo.encrypted) {
                 throw new FileNotFoundException();
             }
 
@@ -749,7 +749,7 @@ public class SeafileProvider extends DocumentsProvider {
         }
 
         SeafRepo repo = dm.getCachedRepoByID(repoId);
-        if (repo.hasWritePermission()) {
+        if (repo != null && repo.hasWritePermission()) {
             if (entry.isDir()) {
                 flags |= Document.FLAG_DIR_SUPPORTS_CREATE;
             } else {


### PR DESCRIPTION
under rare circumstances the seadroid cache might be empty.