### PR TITLE
Camera upload: enabling global sync on android

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/cameraupload/CameraUploadManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/cameraupload/CameraUploadManager.java
@@ -83,6 +83,7 @@ public class CameraUploadManager {
                 // enable camera upload on this account
                 ContentResolver.setIsSyncable(a.getAndroidAccount(), AUTHORITY, 1);
                 ContentResolver.setSyncAutomatically(a.getAndroidAccount(), AUTHORITY, true);
+                ContentResolver.setMasterSyncAutomatically(true); // QUICK HACK
             } else {
                 // disable on all the others
                 ContentResolver.cancelSync(a.getAndroidAccount(), AUTHORITY);


### PR DESCRIPTION
this enables global sync on android whenever seadroid camera upload is being enabled.

This is a quick hack and should never be merged! Its just to check if this might
work on certain custom ROM devices.

If this actually enables global sync, we have to add some crucial UI. This guy makes
some good comments regarding that: http://stackoverflow.com/a/11524302