### PR TITLE
Fix illegal argument exception when resuming Settings page after cleared caches

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/data/StorageManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/StorageManager.java
@@ -480,6 +480,8 @@ public abstract class StorageManager implements MediaScannerConnection.OnScanCom
         File mediaDir = getMediaDir();
         File thumbDir = getThumbnailsDir();
 
+        if (!mediaDir.exists() || !thumbDir.exists()) return 0L;
+
         return FileUtils.sizeOfDirectory(mediaDir) + FileUtils.sizeOfDirectory(thumbDir);
     }
 


### PR DESCRIPTION
Crash log
```
E/AndroidRuntime(21874): Process: com.seafile.seadroid2.debug, PID: 21874
E/AndroidRuntime(21874): java.lang.RuntimeException: An error occured while executing doInBackground()
E/AndroidRuntime(21874): 	at android.os.AsyncTask$3.done(AsyncTask.java:304)
E/AndroidRuntime(21874): 	at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:355)
E/AndroidRuntime(21874): 	at java.util.concurrent.FutureTask.setException(FutureTask.java:222)
E/AndroidRuntime(21874): 	at java.util.concurrent.FutureTask.run(FutureTask.java:242)
E/AndroidRuntime(21874): 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
E/AndroidRuntime(21874): 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
E/AndroidRuntime(21874): 	at java.lang.Thread.run(Thread.java:818)
E/AndroidRuntime(21874): Caused by: java.lang.IllegalArgumentException: /storage/emulated/0/Seafile does not exist
E/AndroidRuntime(21874): 	at org.apache.commons.io.FileUtils.checkDirectory(FileUtils.java:2532)
E/AndroidRuntime(21874): 	at org.apache.commons.io.FileUtils.sizeOfDirectory(FileUtils.java:2468)
E/AndroidRuntime(21874): 	at com.seafile.seadroid2.data.StorageManager.getUsedSpace(StorageManager.java:483)
E/AndroidRuntime(21874): 	at com.seafile.seadroid2.ui.fragment.SettingsFragment$CalculateCacheTask.doInBackground(SettingsFragment.java:524)
E/AndroidRuntime(21874): 	at com.seafile.seadroid2.ui.fragment.SettingsFragment$CalculateCacheTask.doInBackground(SettingsFragment.java:520)
E/AndroidRuntime(21874): 	at android.os.AsyncTask$2.call(AsyncTask.java:292)
E/AndroidRuntime(21874): 	at java.util.concurrent.FutureTask.run(FutureTask.java:237)
```