### PR TITLE
Fix last file chunk might be filled with empty content bug

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/crypto/Crypto.java
+++ b/app/src/main/java/com/seafile/seadroid2/crypto/Crypto.java
@@ -224,16 +224,17 @@ public class Crypto {
      * Do the encryption
      *
      * @param plaintext
+     * @param inputLen
      * @param key
      * @param iv
      * @return
      */
-    private static byte[] seafileEncrypt(@NonNull byte[] plaintext, @NonNull SecretKey key, @NonNull byte[] iv) {
+    private static byte[] seafileEncrypt(@NonNull byte[] plaintext, int inputLen, @NonNull SecretKey key, @NonNull byte[] iv) {
         try {
             Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
             IvParameterSpec ivParams = new IvParameterSpec(iv);
             cipher.init(Cipher.ENCRYPT_MODE, key, ivParams);
-            return cipher.doFinal(plaintext);
+            return cipher.doFinal(plaintext, 0, inputLen);
         } catch (NoSuchAlgorithmException e) {
             e.printStackTrace();
             Log.e(TAG, "NoSuchAlgorithmException " + e.getMessage());
@@ -272,8 +273,23 @@ public class Crypto {
      * @throws UnsupportedEncodingException
      */
     public static byte[] encrypt(@NonNull byte[] plaintext, @NonNull String encKey, @NonNull String iv) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+        return encrypt(plaintext, plaintext.length, encKey, iv);
+    }
+
+    /**
+     * All file data is encrypted by the encKey/encIv with AES 256/CBC.
+     *
+     * @param plaintext
+     * @param inputLen
+     * @param encKey
+     * @param iv
+     * @return
+     * @throws NoSuchAlgorithmException
+     * @throws UnsupportedEncodingException
+     */
+    public static byte[] encrypt(@NonNull byte[] plaintext, int inputLen, @NonNull String encKey, @NonNull String iv) throws NoSuchAlgorithmException, UnsupportedEncodingException {
         SecretKey secretKey = new SecretKeySpec(fromHex(encKey), "AES");
-        return seafileEncrypt(plaintext, secretKey, fromHex(iv));
+        return seafileEncrypt(plaintext, inputLen, secretKey, fromHex(iv));
     }
 
     /**

--- a/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
@@ -1028,8 +1028,14 @@ public class DataManager {
             dis = new DataInputStream(in);
 
             // Log.d(DEBUG_TAG, "file size " + file.length());
-            while (dis.read(buffer, 0, BUFFER_SIZE) != -1) {
-                final byte[] cipher = Crypto.encrypt(buffer, encKey, enkIv);
+            int byteRead;
+            while ((byteRead = dis.read(buffer, 0, BUFFER_SIZE)) != -1) {
+                byte[] cipher;
+                if (byteRead < BUFFER_SIZE)
+                    cipher = Crypto.encrypt(buffer, byteRead, encKey, enkIv);
+                else
+                    cipher = Crypto.encrypt(buffer, encKey, enkIv);
+
                 final String blkid = Crypto.sha1(cipher);
                 File blk = new File(storageManager.getTempDir(), blkid);
                 Block block = new Block(blkid, blk.getAbsolutePath(), blk.length(), 0L);


### PR DESCRIPTION
Note that, the size of the buffer array remains constant. But if the buffer cannot be filled, like when it reaches the end of the file, we should only read and process the valid part. 
This patch uses offset to fix that.