### PR TITLE
Hide client side encryption option if server not supported

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/SettingsManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/SettingsManager.java
@@ -38,6 +38,9 @@ public final class SettingsManager {
     public static final String SETTINGS_ACCOUNT_SPACE_KEY = "account_info_space_key";
     public static final String SETTINGS_ACCOUNT_SIGN_OUT_KEY = "account_sign_out_key";
 
+    // privacy category
+    public static final String PRIVACY_CATEGORY_KEY = "category_privacy_key";
+
     // Client side encryption
     public static final String CLIENT_ENC_SWITCH_KEY = "client_encrypt_switch_key";
     public static final String CLEAR_PASSOWR_SWITCH_KEY = "clear_password_switch_key";

--- a/app/src/main/java/com/seafile/seadroid2/data/ServerInfo.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/ServerInfo.java
@@ -2,7 +2,10 @@ package com.seafile.seadroid2.data;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.TextUtils;
+
 import com.google.common.base.Objects;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -61,6 +64,17 @@ public class ServerInfo implements Parcelable{
 
     public boolean isSearchEnabled() {
         return features != null && features.contains("file-search");
+    }
+
+    public boolean canLocalDecrypt() {
+        if (TextUtils.isEmpty(version)
+                || version.length() != 5)
+            return false;
+
+        final String realVersion = version.replaceAll("[.]", "");
+        final int versionCode = Integer.parseInt(realVersion);
+
+        return versionCode >= 510;
     }
 
     public String getUrl() {

--- a/app/src/main/java/com/seafile/seadroid2/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/fragment/SettingsFragment.java
@@ -25,6 +25,7 @@ import com.seafile.seadroid2.R;
 import com.seafile.seadroid2.SeafException;
 import com.seafile.seadroid2.SettingsManager;
 import com.seafile.seadroid2.data.DatabaseHelper;
+import com.seafile.seadroid2.data.ServerInfo;
 import com.seafile.seadroid2.data.StorageManager;
 import com.seafile.seadroid2.account.Account;
 import com.seafile.seadroid2.account.AccountInfo;
@@ -71,6 +72,9 @@ public class SettingsFragment extends CustomPreferenceFragment {
     private Preference cUploadRepoPref;
     private CheckBoxPreference cCustomDirectoriesPref;
     private Preference cLocalDirectoriesPref;
+    // privacy
+    private PreferenceCategory cPrivacyCategory;
+    private Preference clientEncPref;
 
     private SettingsActivity mActivity;
     private String appVersion;
@@ -224,9 +228,12 @@ public class SettingsFragment extends CustomPreferenceFragment {
             }
         });
 
+        final ServerInfo serverInfo = accountMgr.getServerInfo(currentAccount);
 
+        cPrivacyCategory = (PreferenceCategory) findPreference(SettingsManager.PRIVACY_CATEGORY_KEY);
         // Client side encryption for encrypted Library
-        findPreference(SettingsManager.CLIENT_ENC_SWITCH_KEY).setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+        clientEncPref = findPreference(SettingsManager.CLIENT_ENC_SWITCH_KEY);
+        clientEncPref.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 if (newValue instanceof Boolean) {
@@ -239,6 +246,10 @@ public class SettingsFragment extends CustomPreferenceFragment {
                 return false;
             }
         });
+
+        if (serverInfo != null && !serverInfo.canLocalDecrypt()) {
+            cPrivacyCategory.removePreference(clientEncPref);
+        }
 
         // Camera Upload
         cUploadCategory = (PreferenceCategory) findPreference(SettingsManager.CAMERA_UPLOAD_CATEGORY_KEY);

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -31,6 +31,7 @@
         </Preference>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/security"
+        android:key="category_privacy_key"
         android:layout="@layout/bg_settings_section_security">
         <Preference
             android:key="clear_password_switch_key"


### PR DESCRIPTION
Only server version 5.1+ supports APIs for client side encryption under encrypted libraries, so hide the option for those running on pre 5.1 servers for a better ux.

fix #537