### PR TITLE
Feature/dynamically show password fields

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/ui/dialog/NewRepoDialog.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/dialog/NewRepoDialog.java
@@ -5,7 +5,9 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.CompoundButton;
 import android.widget.EditText;
+import android.widget.Switch;
 
 import com.seafile.seadroid2.R;
 import com.seafile.seadroid2.SeafException;
@@ -40,6 +42,7 @@ public class NewRepoDialog extends TaskDialog {
 
     // The input fields of the dialog
     private EditText mRepoNameText;
+    private Switch mEncryptSwitch;
     private EditText mPasswordText;
     private EditText mPasswordConfirmationText;
 
@@ -67,6 +70,7 @@ public class NewRepoDialog extends TaskDialog {
     protected View createDialogContentView(LayoutInflater inflater, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.dialog_new_repo, null);
         mRepoNameText = (EditText) view.findViewById(R.id.new_repo_name);
+        mEncryptSwitch = (Switch) view.findViewById(R.id.new_repo_encrpyt_switch);
         mPasswordText = (EditText) view.findViewById(R.id.new_repo_password);
         mPasswordConfirmationText = (EditText) view.findViewById(R.id.new_repo_password_confirmation);
 
@@ -74,6 +78,23 @@ public class NewRepoDialog extends TaskDialog {
             // Restore state
             mAccount = (Account) savedInstanceState.getParcelable(STATE_ACCOUNT);
         }
+
+        mEncryptSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                if (isChecked) {
+                    mPasswordText.setVisibility(View.VISIBLE);
+                    mPasswordConfirmationText.setVisibility(View.VISIBLE);
+                } else {
+                    mPasswordText.setVisibility(View.GONE);
+                    mPasswordConfirmationText.setVisibility(View.GONE);
+
+                    // Delete entered passwords so hiding the input fields creates an unencrypted repo
+                    mPasswordText.setText("");
+                    mPasswordConfirmationText.setText("");
+                }
+            }
+        });
 
         return view;
     }
@@ -95,6 +116,16 @@ public class NewRepoDialog extends TaskDialog {
         if (getRepoName().length() == 0) {
             throw new Exception(getResources().getString(R.string.repo_name_empty));
         }
+
+        if (mEncryptSwitch.isChecked()) {
+            if (getPassword().length() == 0) {
+                throw new Exception(getResources().getString(R.string.err_passwd_empty));
+            }
+
+            if (!getPassword().equals(getPasswordConfirmation())) {
+                throw new Exception(getResources().getString(R.string.err_passwd_mismatch));
+            }
+        }
     }
 
     @Override
@@ -106,6 +137,7 @@ public class NewRepoDialog extends TaskDialog {
     protected void disableInput() {
         super.disableInput();
         mRepoNameText.setEnabled(false);
+        mEncryptSwitch.setEnabled(false);
         mPasswordText.setEnabled(false);
         mPasswordConfirmationText.setEnabled(false);
     }
@@ -114,6 +146,7 @@ public class NewRepoDialog extends TaskDialog {
     protected void enableInput() {
         super.enableInput();
         mRepoNameText.setEnabled(true);
+        mEncryptSwitch.setEnabled(true);
         mPasswordText.setEnabled(true);
         mPasswordConfirmationText.setEnabled(true);
     }

--- a/app/src/main/java/com/seafile/seadroid2/ui/dialog/NewRepoDialog.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/dialog/NewRepoDialog.java
@@ -70,7 +70,7 @@ public class NewRepoDialog extends TaskDialog {
     protected View createDialogContentView(LayoutInflater inflater, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.dialog_new_repo, null);
         mRepoNameText = (EditText) view.findViewById(R.id.new_repo_name);
-        mEncryptSwitch = (SwitchCompat) view.findViewById(R.id.new_repo_encrpyt_switch);
+        mEncryptSwitch = (SwitchCompat) view.findViewById(R.id.new_repo_encrypt_switch);
         mPasswordText = (EditText) view.findViewById(R.id.new_repo_password);
         mPasswordConfirmationText = (EditText) view.findViewById(R.id.new_repo_password_confirmation);
 

--- a/app/src/main/java/com/seafile/seadroid2/ui/dialog/NewRepoDialog.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/dialog/NewRepoDialog.java
@@ -41,6 +41,7 @@ public class NewRepoDialog extends TaskDialog {
     // The input fields of the dialog
     private EditText mRepoNameText;
     private EditText mPasswordText;
+    private EditText mPasswordConfirmationText;
 
     private Account mAccount;
     private DataManager mDataManager;
@@ -60,12 +61,14 @@ public class NewRepoDialog extends TaskDialog {
 
     public String getRepoName() { return mRepoNameText.getText().toString().trim(); }
     private String getPassword() { return mPasswordText.getText().toString().trim(); }
+    private String getPasswordConfirmation() { return mPasswordConfirmationText.getText().toString().trim(); }
 
     @Override
     protected View createDialogContentView(LayoutInflater inflater, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.dialog_new_repo, null);
         mRepoNameText = (EditText) view.findViewById(R.id.new_repo_name);
         mPasswordText = (EditText) view.findViewById(R.id.new_repo_password);
+        mPasswordConfirmationText = (EditText) view.findViewById(R.id.new_repo_password_confirmation);
 
         if (savedInstanceState != null) {
             // Restore state
@@ -104,6 +107,7 @@ public class NewRepoDialog extends TaskDialog {
         super.disableInput();
         mRepoNameText.setEnabled(false);
         mPasswordText.setEnabled(false);
+        mPasswordConfirmationText.setEnabled(false);
     }
 
     @Override
@@ -111,5 +115,6 @@ public class NewRepoDialog extends TaskDialog {
         super.enableInput();
         mRepoNameText.setEnabled(true);
         mPasswordText.setEnabled(true);
+        mPasswordConfirmationText.setEnabled(true);
     }
 }

--- a/app/src/main/java/com/seafile/seadroid2/ui/dialog/NewRepoDialog.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/dialog/NewRepoDialog.java
@@ -2,12 +2,12 @@ package com.seafile.seadroid2.ui.dialog;
 
 import android.app.Dialog;
 import android.os.Bundle;
+import android.support.v7.widget.SwitchCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
 import android.widget.CompoundButton;
 import android.widget.EditText;
-import android.widget.Switch;
 
 import com.seafile.seadroid2.R;
 import com.seafile.seadroid2.SeafException;
@@ -42,7 +42,7 @@ public class NewRepoDialog extends TaskDialog {
 
     // The input fields of the dialog
     private EditText mRepoNameText;
-    private Switch mEncryptSwitch;
+    private SwitchCompat mEncryptSwitch;
     private EditText mPasswordText;
     private EditText mPasswordConfirmationText;
 
@@ -70,7 +70,7 @@ public class NewRepoDialog extends TaskDialog {
     protected View createDialogContentView(LayoutInflater inflater, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.dialog_new_repo, null);
         mRepoNameText = (EditText) view.findViewById(R.id.new_repo_name);
-        mEncryptSwitch = (Switch) view.findViewById(R.id.new_repo_encrpyt_switch);
+        mEncryptSwitch = (SwitchCompat) view.findViewById(R.id.new_repo_encrpyt_switch);
         mPasswordText = (EditText) view.findViewById(R.id.new_repo_password);
         mPasswordConfirmationText = (EditText) view.findViewById(R.id.new_repo_password_confirmation);
 

--- a/app/src/main/res/layout/dialog_new_repo.xml
+++ b/app/src/main/res/layout/dialog_new_repo.xml
@@ -17,13 +17,34 @@
         android:textSize="@dimen/dialog_msg_txt_size"
         android:inputType="text" />
 
-    <EditText
-        android:id="@+id/new_repo_password"
-        android:hint="@string/passwd_hint"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@drawable/edit_text_holo_light"
-        android:textSize="@dimen/dialog_msg_txt_size"
-        android:inputType="textPassword" />
+    <android.support.v4.widget.NestedScrollView
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent" >
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <EditText
+                android:id="@+id/new_repo_password"
+                android:hint="@string/passwd_hint"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/edit_text_holo_light"
+                android:textSize="@dimen/dialog_msg_txt_size"
+                android:inputType="textPassword"
+                android:visibility="gone" />
+
+            <EditText
+                android:id="@+id/new_repo_password_confirmation"
+                android:hint="@string/passwd_confirmation_hint"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@drawable/edit_text_holo_light"
+                android:textSize="@dimen/dialog_msg_txt_size"
+                android:inputType="textPassword"
+                android:visibility="gone" />
+        </LinearLayout>
+    </android.support.v4.widget.NestedScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_new_repo.xml
+++ b/app/src/main/res/layout/dialog_new_repo.xml
@@ -36,7 +36,11 @@
             android:layout_height="wrap_content"
             android:checked="false"
             android:layout_toRightOf="@id/new_repo_encrpyt_switch"
+            android:layout_toEndOf="@id/new_repo_encrpyt_switch"
             android:paddingLeft="3dp"
+            android:paddingRight="3dp"
+            android:paddingStart="3dp"
+            android:paddingEnd="3dp"
             android:textSize="@dimen/dialog_msg_txt_size"
             android:text="@string/encrypt" />
     </RelativeLayout>

--- a/app/src/main/res/layout/dialog_new_repo.xml
+++ b/app/src/main/res/layout/dialog_new_repo.xml
@@ -17,6 +17,30 @@
         android:textSize="@dimen/dialog_msg_txt_size"
         android:inputType="text" />
 
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingBottom="10dp"
+        android:paddingLeft="10dp"
+        android:paddingRight="10dp"
+        android:paddingTop="15dp">
+
+        <Switch
+            android:id="@+id/new_repo_encrpyt_switch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="false" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="false"
+            android:layout_toRightOf="@id/new_repo_encrpyt_switch"
+            android:paddingLeft="3dp"
+            android:textSize="@dimen/dialog_msg_txt_size"
+            android:text="@string/encrypt" />
+    </RelativeLayout>
+
     <android.support.v4.widget.NestedScrollView
         android:layout_width="wrap_content"
         android:layout_height="match_parent" >

--- a/app/src/main/res/layout/dialog_new_repo.xml
+++ b/app/src/main/res/layout/dialog_new_repo.xml
@@ -25,7 +25,7 @@
         android:paddingRight="10dp"
         android:paddingTop="15dp">
 
-        <Switch
+        <android.support.v7.widget.SwitchCompat
             android:id="@+id/new_repo_encrpyt_switch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_new_repo.xml
+++ b/app/src/main/res/layout/dialog_new_repo.xml
@@ -26,7 +26,7 @@
         android:paddingTop="15dp">
 
         <android.support.v7.widget.SwitchCompat
-            android:id="@+id/new_repo_encrpyt_switch"
+            android:id="@+id/new_repo_encrypt_switch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="false" />
@@ -35,8 +35,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="false"
-            android:layout_toRightOf="@id/new_repo_encrpyt_switch"
-            android:layout_toEndOf="@id/new_repo_encrpyt_switch"
+            android:layout_toRightOf="@id/new_repo_encrypt_switch"
+            android:layout_toEndOf="@id/new_repo_encrypt_switch"
             android:paddingLeft="3dp"
             android:paddingRight="3dp"
             android:paddingStart="3dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="err_server_andress_empty">Server address can\`t be empty</string>
     <string name="err_email_empty">Email can\`t be empty</string>
     <string name="err_passwd_empty">Password can\`t be empty</string>
+    <string name="err_passwd_mismatch">The passwords don\`t match</string>
     <string name="err_login_failed">Login failed</string>
     <string name="err_wrong_user_or_passwd">Email or password error</string>
     <string name="err_token_expired">Authentication expired, please login again</string>
@@ -126,6 +127,7 @@
     <string name="load_dir_fail">Failed to load contents of this folder</string>
     <string name="not_supported_share">This type of share is not supported</string>
     <string name="edit">Edit</string>
+    <string name="encrypt">Encrypt</string>
     <string name="download_folder">Download folder</string>
     <string name="download_folder_title">Choose your preferred option</string>
     <string-array name="download_folder_options_array">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     <string name="server_hint">Server address</string>
     <string name="email_hint">Email or Username</string>
     <string name="passwd_hint">Password</string>
+    <string name="passwd_confirmation_hint">Password again</string>
     <string name="login">Log In</string>
     <string name="open_file">Open</string>
     <string name="download_file">Download</string>


### PR DESCRIPTION
[As discussed](https://github.com/haiwen/seadroid/pull/557#issuecomment-235459353) this PR adds a second password field when creating a new repo to check for consistency and a switch to hide the input fields when creating an unencrypted repo (default).

Imperfections:
 - The dialog isn't wide enough
    - If stating a minimum length for the password in the `hint`, it is cut off
    - Therefore no minimum length is enforced during input validation
       - Adding the check would be easy, getting the hint to display nicely maybe not so much
 - The dialog isn't high enough
    - On devices with smaller displays (<5"), the second password field was collapsed when displaying the virtual keyboard with a suggestion line
    - The password fields are therefore wrapped in a scrollable container, which handles the situation more gracefully