### PR TITLE
Make explicit manual refreshs hit the server

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/ui/fragment/ReposFragment.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/fragment/ReposFragment.java
@@ -138,7 +138,7 @@ public class ReposFragment extends ListFragment {
             @Override
             public void onRefresh() {
                 mRefreshType = REFRESH_ON_PULL;
-                refreshView(true);
+                refreshView(true, true);
             }
         });
 


### PR DESCRIPTION
So far pull-to-refresh hits the local caches for repos, dirs and files, missing
current changes on the server.

This commit `forceRefresh`es the view so the server is hit and changes induced
by other clients are synced.

Fixes haiwen/seadroid#558.