### PR TITLE
Fix blocks download progress inaccurate bug

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/SeafConnection.java
+++ b/app/src/main/java/com/seafile/seadroid2/SeafConnection.java
@@ -513,11 +513,12 @@ public class SeafConnection {
                                        FileBlocks fileBlocks,
                                        String blockId,
                                        String localPath,
+                                       long fileSize,
                                        ProgressMonitor monitor) throws SeafException, IOException, JSONException {
 
         String dlink = getBlockDownloadLink(repoID, fileBlocks.fileID, blockId).replaceAll("\"", "");
 
-        File block = getBlockFromLink(dlink, fileBlocks, blockId, localPath, monitor);
+        File block = getBlockFromLink(dlink, fileBlocks, blockId, localPath, fileSize, monitor);
         if (block != null) {
             return new Pair<>(blockId, block);
         } else {
@@ -597,7 +598,7 @@ public class SeafConnection {
         }
     }
 
-    private File getBlockFromLink(String dlink, FileBlocks fileBlocks, String blkId, String localPath, ProgressMonitor monitor)
+    private File getBlockFromLink(String dlink, FileBlocks fileBlocks, String blkId, String localPath, long fileSize, ProgressMonitor monitor)
                                     throws SeafException {
         if (dlink == null)
             return null;
@@ -613,8 +614,7 @@ public class SeafConnection {
                 }
                 Long size = Long.parseLong(req.header(HttpRequest.HEADER_CONTENT_LENGTH));*/
                 if (req.contentLength() > 0) {
-                    fileBlocks.getBlock(blkId).size = req.contentLength();
-                    monitor.onProgressNotify(fileBlocks.getSize(), true);
+                    monitor.onProgressNotify(fileSize, true);
                 }
             }
 

--- a/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/data/DataManager.java
@@ -413,7 +413,7 @@ public class DataManager {
         }
     }
 
-    public synchronized File getFileByBlocks(String repoName, String repoID, String path, int version,
+    public synchronized File getFileByBlocks(String repoName, String repoID, String path, int version, long fileSize,
                         ProgressMonitor monitor) throws SeafException, IOException, JSONException, NoSuchAlgorithmException {
 
         String cachedFileID = null;
@@ -455,7 +455,7 @@ public class DataManager {
 
         for (Block blk : fileBlocks.blocks) {
             File tempBlock = new File(storageManager.getTempDir(), blk.blockId);
-            final Pair<String, File> block = sc.getBlock(repoID, fileBlocks, blk.blockId, tempBlock.getPath(), monitor);
+            final Pair<String, File> block = sc.getBlock(repoID, fileBlocks, blk.blockId, tempBlock.getPath(), fileSize, monitor);
             final byte[] bytes = FileUtils.readFileToByteArray(block.second);
             final byte[] decryptedBlock = Crypto.decrypt(bytes, encKey, encIv);
             FileUtils.writeByteArrayToFile(localFile, decryptedBlock, true);

--- a/app/src/main/java/com/seafile/seadroid2/transfer/DownloadTask.java
+++ b/app/src/main/java/com/seafile/seadroid2/transfer/DownloadTask.java
@@ -52,7 +52,7 @@ public class DownloadTask extends TransferTask {
         try {
             DataManager dataManager = new DataManager(account);
             if (byBlock) {
-                return dataManager.getFileByBlocks(repoName, repoID, path, encVersion,
+                return dataManager.getFileByBlocks(repoName, repoID, path, encVersion, totalSize,
                         new ProgressMonitor() {
 
                             @Override

--- a/app/src/main/java/com/seafile/seadroid2/transfer/DownloadTaskManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/transfer/DownloadTaskManager.java
@@ -30,14 +30,6 @@ public class DownloadTaskManager extends TransferManager implements DownloadStat
      * Add a new download task.
      * call this method to execute a task immediately.
      */
-    public int addTask(Account account, String repoName, String repoID, String path) {
-        return addTask(account, repoName, repoID, path, false, -1, 0L);
-    }
-
-    /**
-     * Add a new download task.
-     * call this method to execute a task immediately.
-     */
     public int addTask(Account account, String repoName, String repoID, String path, boolean byBlock, int encVersion, long fileSize) {
         TransferTask task = new DownloadTask(++notificationID, account, repoName, repoID, path, byBlock, encVersion, this);
         task.totalSize = fileSize;

--- a/app/src/main/java/com/seafile/seadroid2/transfer/DownloadTaskManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/transfer/DownloadTaskManager.java
@@ -31,15 +31,16 @@ public class DownloadTaskManager extends TransferManager implements DownloadStat
      * call this method to execute a task immediately.
      */
     public int addTask(Account account, String repoName, String repoID, String path) {
-        return addTask(account, repoName, repoID, path, false, -1);
+        return addTask(account, repoName, repoID, path, false, -1, 0L);
     }
 
     /**
      * Add a new download task.
      * call this method to execute a task immediately.
      */
-    public int addTask(Account account, String repoName, String repoID, String path, boolean byBlock, int encVersion) {
+    public int addTask(Account account, String repoName, String repoID, String path, boolean byBlock, int encVersion, long fileSize) {
         TransferTask task = new DownloadTask(++notificationID, account, repoName, repoID, path, byBlock, encVersion, this);
+        task.totalSize = fileSize;
         TransferTask oldTask = null;
         if (allTaskList.contains(task)) {
             oldTask = allTaskList.get(allTaskList.indexOf(task));

--- a/app/src/main/java/com/seafile/seadroid2/transfer/TransferService.java
+++ b/app/src/main/java/com/seafile/seadroid2/transfer/TransferService.java
@@ -204,11 +204,11 @@ public class TransferService extends Service {
 
     // -------------------------- download task --------------------//
     public int addDownloadTask(Account account, String repoName, String repoID, String path) {
-        return addDownloadTask(account, repoName, repoID, path, false, -1);
+        return addDownloadTask(account, repoName, repoID, path, false, -1, 0L);
     }
 
-    public int addDownloadTask(Account account, String repoName, String repoID, String path, boolean byBlock, int encVersion) {
-        return downloadTaskManager.addTask(account, repoName, repoID, path, byBlock, encVersion);
+    public int addDownloadTask(Account account, String repoName, String repoID, String path, boolean byBlock, int encVersion, long fileSize) {
+        return downloadTaskManager.addTask(account, repoName, repoID, path, byBlock, encVersion, fileSize);
     }
 
     public void addTaskToDownloadQue(Account account, String repoName, String repoID, String path) {

--- a/app/src/main/java/com/seafile/seadroid2/transfer/TransferService.java
+++ b/app/src/main/java/com/seafile/seadroid2/transfer/TransferService.java
@@ -204,7 +204,7 @@ public class TransferService extends Service {
 
     // -------------------------- download task --------------------//
     public int addDownloadTask(Account account, String repoName, String repoID, String path) {
-        return addDownloadTask(account, repoName, repoID, path, false, -1, 0L);
+        return addDownloadTask(account, repoName, repoID, path, false, -1, -1L);
     }
 
     public int addDownloadTask(Account account, String repoName, String repoID, String path, boolean byBlock, int encVersion, long fileSize) {

--- a/app/src/main/java/com/seafile/seadroid2/ui/activity/BrowserActivity.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/activity/BrowserActivity.java
@@ -1501,6 +1501,7 @@ public class BrowserActivity extends BaseActivity
     @Override
     public void onFileSelected(SeafDirent dirent) {
         final String fileName= dirent.name;
+        final long fileSize = dirent.size;
         final String repoName = navContext.getRepoName();
         final String repoID = navContext.getRepoID();
         final String dirPath = navContext.getDirPath();
@@ -1523,7 +1524,7 @@ public class BrowserActivity extends BaseActivity
 
         if (repo == null) return;
 
-        startFileActivity(repoName, repoID, filePath, repo.canLocalDecrypt(), repo.encVersion);
+        startFileActivity(repoName, repoID, filePath, repo.canLocalDecrypt(), repo.encVersion, fileSize);
     }
 
     /**
@@ -1685,10 +1686,10 @@ public class BrowserActivity extends BaseActivity
         }
     }
 
-    private void startFileActivity(String repoName, String repoID, String filePath, boolean byBlock, int encVersion) {
+    private void startFileActivity(String repoName, String repoID, String filePath, boolean byBlock, int encVersion, long fileSize) {
         int taskID = 0;
         if (byBlock) {
-            taskID = txService.addDownloadTask(account, repoName, repoID, filePath, true, encVersion);
+            taskID = txService.addDownloadTask(account, repoName, repoID, filePath, true, encVersion, fileSize);
         } else {
             taskID = txService.addDownloadTask(account, repoName, repoID, filePath);
         }
@@ -1703,7 +1704,7 @@ public class BrowserActivity extends BaseActivity
 
     @Override
     public void onStarredFileSelected(final SeafStarredFile starredFile) {
-
+        final long fileSize = starredFile.getSize();
         final String repoID = starredFile.getRepoID();
         final SeafRepo repo = dataManager.getCachedRepoByID(repoID);
         if (repo == null) return;
@@ -1735,7 +1736,7 @@ public class BrowserActivity extends BaseActivity
             return;
         }
 
-        startFileActivity(repoName, repoID, filePath, repo.canLocalDecrypt(), repo.encVersion);
+        startFileActivity(repoName, repoID, filePath, repo.canLocalDecrypt(), repo.encVersion, fileSize);
     }
 
     @Override

--- a/app/src/main/java/com/seafile/seadroid2/ui/fragment/ActivitiesFragment.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/fragment/ActivitiesFragment.java
@@ -8,7 +8,6 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.util.Log;
-import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,10 +25,11 @@ import com.google.common.collect.Lists;
 import com.seafile.seadroid2.R;
 import com.seafile.seadroid2.SeafException;
 import com.seafile.seadroid2.data.CommitDetails;
-import com.seafile.seadroid2.data.DataManager;
 import com.seafile.seadroid2.data.EventDetailsFileItem;
 import com.seafile.seadroid2.data.EventDetailsTree;
 import com.seafile.seadroid2.data.SeafActivities;
+import com.seafile.seadroid2.data.SeafCachedFile;
+import com.seafile.seadroid2.data.SeafDirent;
 import com.seafile.seadroid2.data.SeafEvent;
 import com.seafile.seadroid2.data.SeafRepo;
 import com.seafile.seadroid2.ui.NavContext;
@@ -511,12 +511,22 @@ public class ActivitiesFragment extends Fragment {
     }
 
     private void openFile(String repoID, String repoName, String filePath) {
-        // Log.d(DEBUG_TAG, "open fiel " + repoName + filePath);
+        // Log.d(DEBUG_TAG, "open file " + repoName + filePath);
         final SeafRepo repo = mActivity.getDataManager().getCachedRepoByID(repoID);
+        final String parentPath = Utils.getParentPath(filePath);
+        final List<SeafDirent> cachedDirents = mActivity.getDataManager().getCachedDirents(repoID, parentPath);
+        long fileSize = 0L;
+        if (cachedDirents != null) {
+            for (SeafDirent seafDirent : cachedDirents) {
+                if (seafDirent.name.equals(filePath)) {
+                    fileSize = seafDirent.size;
+                }
+            }
+        }
 
         int taskID;
         if (repo != null && repo.canLocalDecrypt()) {
-            taskID = mActivity.getTransferService().addDownloadTask(mActivity.getAccount(), repoName, repoID, filePath, true, repo.encVersion);
+            taskID = mActivity.getTransferService().addDownloadTask(mActivity.getAccount(), repoName, repoID, filePath, true, repo.encVersion, fileSize);
         } else {
             taskID = mActivity.getTransferService().addDownloadTask(mActivity.getAccount(), repoName, repoID, filePath);
         }

--- a/app/src/main/java/com/seafile/seadroid2/util/Utils.java
+++ b/app/src/main/java/com/seafile/seadroid2/util/Utils.java
@@ -154,6 +154,10 @@ public class Utils {
             return null;
         }
 
+        if (!path.contains("/")) {
+            return "/";
+        }
+
         String parent = path.substring(0, path.lastIndexOf("/"));
         if (parent.equals("")) {
             return "/";


### PR DESCRIPTION
When calculating blocks downloading progress, use pre known file size instead of summing it up block by block. This should fix the download progress inaccurate bug.
