### PR TITLE
Fixed infinite cycle in reorder certificates chain.

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/ssl/SSLTrustManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/ssl/SSLTrustManager.java
@@ -160,7 +160,10 @@ public final class SSLTrustManager {
         chainList.add(certChain);
         Principal certIssuer = certChain.getIssuerDN();
         Principal certSubject = certChain.getSubjectDN();
+        int numCerts = certs.size();
+        int i = 0;
         while(!certs.isEmpty()){
+            ++i;
             List<X509Certificate> tempcerts = ImmutableList.copyOf(certs);
             for (X509Certificate cert : tempcerts) {
                 if(cert.getIssuerDN().equals(certSubject)){
@@ -176,6 +179,10 @@ public final class SSLTrustManager {
                     certs.remove(cert);
                     continue;
                 }
+            }
+
+            if (i > numCerts) {
+                break;
             }
         }
 


### PR DESCRIPTION
I am using private Seafile server with StartSSL Class 1 certificate. Method orderCerts ends in infinite cycle for this certificate. This commit fixes it.
