### PR TITLE
Fix progress indeterminateDuration integer inconsistent bug

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/ui/fragment/ReposFragment.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/fragment/ReposFragment.java
@@ -463,9 +463,9 @@ public class ReposFragment extends ListFragment {
                 adapter.setDownloadTaskList(ts.getDownloadTaskInfosByPath(repoID, currentDir));
 
                 // Log.d(DEBUG_TAG, "timer post refresh signal " + System.currentTimeMillis());
-                mTimer.postDelayed(this, 1 * 1000);
+                mTimer.postDelayed(this, 1 * 3500);
             }
-        }, 1 * 1000);
+        }, 1 * 3500);
     }
 
     public void stopTimer() {


### PR DESCRIPTION
In order to make downloading animation looks smooth, the indeterminateDuration of the progressbar should be the same value with system default. So set `indeterminateDuration` to be 3500 milliseconds.

https://github.com/android/platform_frameworks_base/blob/master/core/res/res/values/attrs.xml#L3966
https://github.com/android/platform_frameworks_base/blob/master/core/res/res/values/styles.xml#L398