### PR TITLE
Fix bizarre percentage when downloading large files

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/SeafConnection.java
+++ b/app/src/main/java/com/seafile/seadroid2/SeafConnection.java
@@ -556,14 +556,16 @@ public class SeafConnection {
             checkRequestResponseStatus(req, HttpURLConnection.HTTP_OK);
 
             if (monitor != null) {
-                /*if (req.header(HttpRequest.HEADER_CONTENT_LENGTH) == null) {
-                    throw SeafException.illFormatException;
-                }
-                Long size = Long.parseLong(req.header(HttpRequest.HEADER_CONTENT_LENGTH));*/
+                Long size;
                 if (req.contentLength() > 0) {
-                    Long size =  Long.valueOf(req.contentLength());
-                    monitor.onProgressNotify(size, false);
+                    size =  Long.valueOf(req.contentLength());
+                } else {
+                    /*if (req.header(HttpRequest.HEADER_CONTENT_LENGTH) == null) {
+                        throw SeafException.illFormatException;
+                    }*/
+                    size = Long.parseLong(req.header(HttpRequest.HEADER_CONTENT_LENGTH));
                 }
+                monitor.onProgressNotify(size, false);
             }
 
             File tmp = DataManager.createTempFile();

--- a/app/src/test/java/com/seafile/seadroid2/util/UtilsTest.java
+++ b/app/src/test/java/com/seafile/seadroid2/util/UtilsTest.java
@@ -5,6 +5,8 @@ import org.junit.Assert;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
+import java.text.DecimalFormat;
+
 @RunWith(RobolectricTestRunner.class)
 public class UtilsTest {
     @Test
@@ -33,4 +35,20 @@ public class UtilsTest {
         result = Utils.pathJoin("/a/", "/b/c/", "/d/e");
         Assert.assertEquals("/a/b/c/d/e", result);
     }
+
+    @Test
+    public void testReadableFileSize() {
+        String result = Utils.readableFileSize(0);
+        Assert.assertEquals("0 KB", result);
+
+        result = Utils.readableFileSize(957498560);
+        Assert.assertEquals("957.5 MB", result);
+
+        result = Utils.readableFileSize(2579477837L);
+        Assert.assertEquals("2.6 GB", result);
+
+        result = Utils.readableFileSize(285008);
+        Assert.assertEquals("285 KB", result);
+    }
+
 }


### PR DESCRIPTION
The bug is `req.contentLength` will return -1 when downloading large (e.g. 2.6GB) file.
This patch should fix #570 