### PR TITLE
Support using imported client identity

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/ssl/KeyChainKeyManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/ssl/KeyChainKeyManager.java
@@ -1,0 +1,89 @@
+package com.seafile.seadroid2.ssl;
+
+import android.content.Context;
+import android.security.KeyChain;
+import android.security.KeyChainException;
+import android.util.Log;
+
+import java.net.Socket;
+import java.security.Principal;
+import java.security.PrivateKey;
+
+import javax.net.ssl.X509KeyManager;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+/**
+ * KeyManager to support client side authentication
+ */
+public class KeyChainKeyManager implements X509KeyManager {
+    public static final String DEBUG_TAG = "KeyChainKeyManager";
+
+    private final String mClientAlias;
+    private final X509Certificate[] mCertificateChain;
+    private final PrivateKey mPrivateKey;
+
+    public static KeyChainKeyManager fromAlias(Context context, String alias)
+            throws CertificateException {
+        X509Certificate[] certificateChain;
+        try {
+            certificateChain = KeyChain.getCertificateChain(context, alias);
+        } catch (KeyChainException | InterruptedException e) {
+            Log.e(DEBUG_TAG, String.format("alias %s certificate chain error", alias, e.getMessage()));
+            throw new CertificateException(e);
+        }
+
+        PrivateKey privateKey;
+        try {
+            privateKey = KeyChain.getPrivateKey(context, alias);
+        } catch (KeyChainException | InterruptedException e) {
+            Log.e(DEBUG_TAG, String.format("alias %s private key error", alias, e.getMessage()));
+            throw new CertificateException(e);
+        }
+
+        if (certificateChain == null || privateKey == null) {
+            throw new CertificateException("Can't access certificate from keystore");
+        }
+
+        return new KeyChainKeyManager(alias, certificateChain, privateKey);
+    }
+
+    private KeyChainKeyManager(
+            String clientAlias, X509Certificate[] certificateChain,
+            PrivateKey privateKey) {
+        mClientAlias = clientAlias;
+        mCertificateChain = certificateChain;
+        mPrivateKey = privateKey;
+    }
+
+
+    @Override
+    public String chooseClientAlias(String[] keyTypes, Principal[] issuers, Socket socket) {
+        return mClientAlias;
+    }
+
+    @Override
+    public String chooseServerAlias(String keyType, Principal[] issuers, Socket socket) {
+        return null;
+    }
+
+    @Override
+    public X509Certificate[] getCertificateChain(String alias) {
+        return mCertificateChain;
+    }
+
+    @Override
+    public String[] getClientAliases(String keyType, Principal[] issuers) {
+        return new String[0];
+    }
+
+    @Override
+    public String[] getServerAliases(String keyType, Principal[] issuers) {
+        return new String[0];
+    }
+
+    @Override
+    public PrivateKey getPrivateKey(String alias) {
+        return mPrivateKey;
+    }
+}


### PR DESCRIPTION
Client side doesn't know ahead of time if the server is going to want a client cert, so they install a manager to record the fact that a cert was requested, then do some UI to ask the user what they want to use, then use a different one configured with the user`s choice. 

useful links
1. [Unifying Key Store Access in ICS](http://android-developers.blogspot.jp/2012/03/unifying-key-store-access-in-ics.html?m=0)
2. [ClientCertRequest](https://developer.android.com/reference/android/webkit/ClientCertRequest.html)
3. [Add Android support for SSL client authentication to the browser layer](https://groups.google.com/a/chromium.org/forum/#!msg/chromium-reviews/ZLiOx9qige8/_D7KyA5ocLIJ)
4. [Are two way SSL handshakes supported on Android?](https://groups.google.com/forum/#!topic/android-security-discuss/Ruwk0y5YtbI)
