### PR TITLE
Android automatic refactor - Recycle

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/ui/activity/ShareToSeafileActivity.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/activity/ShareToSeafileActivity.java
@@ -72,9 +72,15 @@ public class ShareToSeafileActivity extends BaseActivity {
             ContentResolver contentResolver = getContentResolver();
             Cursor cursor = contentResolver.query(uri, null, null, null, null);
             if (cursor == null || !cursor.moveToFirst()) {
-                return null;
+                if (cursor != null) {
+					cursor.close();
+				}
+				return null;
             }
             String filePath = cursor.getString(cursor.getColumnIndex(Images.Media.DATA));
+			if (cursor != null) {
+				cursor.close();
+			}
             return filePath;
         }
     }

--- a/app/src/main/java/com/seafile/seadroid2/util/Utils.java
+++ b/app/src/main/java/com/seafile/seadroid2/util/Utils.java
@@ -546,11 +546,18 @@ public class Utils {
                 int column_index = cursor
                 .getColumnIndexOrThrow("_data");
                 if (cursor.moveToFirst()) {
-                    return cursor.getString(column_index);
+                    final String returnValueAutoRefactor = cursor.getString(column_index);
+					if (cursor != null) {
+						cursor.close();
+					}
+					return returnValueAutoRefactor;
                 }
             } catch (Exception e) {
                 // Eat it
             }
+			if (cursor != null) {
+				cursor.close();
+			}
         }
         else if ("file".equalsIgnoreCase(uri.getScheme())) {
             return uri.getPath();


### PR DESCRIPTION
Hi,

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "Recycle".

Some resources (e.g., ```Cursor``` instances) should be closed when they are no longer necessary. 

I have made a previous validation of the changes and they seem correct.
Please consider them and let me know if you agree with them.

Best,
Luis