### PR TITLE
Android automatic refactor - ObsoleteLayoutParam

### DIFF
--- a/app/src/main/res/layout/bucket_item.xml
+++ b/app/src/main/res/layout/bucket_item.xml
@@ -1,44 +1,43 @@
-<?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+<?xml version='1.0' encoding='utf-8'?>
+  <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent">
 
-    <ImageView
-        android:id="@+id/bucket_item_thumbImage"
-        android:layout_width="200dp"
-        android:layout_height="150dp"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentTop="true"
-        android:src="@drawable/ic_launcher"
-        android:scaleType="centerCrop" />
+  <ImageView android:id="@+id/bucket_item_thumbImage"
+    android:layout_width="200dp"
+    android:layout_height="150dp"
+    android:src="@drawable/ic_launcher"
+    android:scaleType="centerCrop">
+    <!--Removed ObsoleteLayoutParam: layout_alignParentLeft-->
+    <!--Removed ObsoleteLayoutParam: layout_alignParentTop-->
+  </ImageView>
 
-    <ImageView
-        android:id="@+id/bucket_item_text_background"
-        android:layout_width="200dp"
-        android:layout_height="25dp"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentLeft="true"
-        android:alpha="0.5"
-        android:background="#000000" />
+  <ImageView android:id="@+id/bucket_item_text_background"
+    android:layout_width="200dp"
+    android:layout_height="25dp"
+    android:alpha="0.5"
+    android:background="#000000">
+    <!--Removed ObsoleteLayoutParam: layout_alignParentBottom-->
+    <!--Removed ObsoleteLayoutParam: layout_alignParentLeft-->
+  </ImageView>
 
-    <ImageView
-        android:id="@+id/bucket_item_marking"
-        android:layout_width="200dp"
-        android:layout_height="150dp"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentTop="true"
-        android:background="@drawable/camera_bucket_selected"
-        android:alpha="0.7" />
+  <ImageView android:id="@+id/bucket_item_marking"
+    android:layout_width="200dp"
+    android:layout_height="150dp"
+    android:background="@drawable/camera_bucket_selected"
+    android:alpha="0.7">
+    <!--Removed ObsoleteLayoutParam: layout_alignParentLeft-->
+    <!--Removed ObsoleteLayoutParam: layout_alignParentTop-->
+  </ImageView>
 
-    <TextView
-        android:id="@+id/bucket_item_name"
-        android:layout_width="200dp"
-        android:layout_height="25dp"
-        android:layout_alignParentBottom="true"
-        android:layout_alignParentLeft="true"
-        android:textColor="#ffffff"
-        android:layout_marginLeft="10dp"
-        android:layout_marginTop="5dp"
-        android:layout_marginRight="5dp" />
-
+  <TextView android:id="@+id/bucket_item_name"
+    android:layout_width="200dp"
+    android:layout_height="25dp"
+    android:textColor="#ffffff"
+    android:layout_marginLeft="10dp"
+    android:layout_marginTop="5dp"
+    android:layout_marginRight="5dp">
+    <!--Removed ObsoleteLayoutParam: layout_alignParentBottom-->
+    <!--Removed ObsoleteLayoutParam: layout_alignParentLeft-->
+  </TextView>
 </FrameLayout>

--- a/app/src/main/res/layout/cuc_multi_selection_layout.xml
+++ b/app/src/main/res/layout/cuc_multi_selection_layout.xml
@@ -1,121 +1,109 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent">
+<?xml version='1.0' encoding='UTF-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent">
 
-    <RelativeLayout
-            android:id="@+id/cuc_multi_selection_up_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:selectableItemBackground"
-            android:layout_alignParentTop="true">
+  <RelativeLayout android:id="@+id/cuc_multi_selection_up_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:selectableItemBackground"
+    android:layout_alignParentTop="true">
 
-        <ImageView
-                android:id="@+id/cuc_multi_selection_up_icon"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentLeft="true"
-                android:layout_centerVertical="true"
-                android:paddingLeft="10dp"
-                android:src="@drawable/up"/>
+    <ImageView android:id="@+id/cuc_multi_selection_up_icon"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_alignParentLeft="true"
+      android:layout_centerVertical="true"
+      android:paddingLeft="10dp"
+      android:src="@drawable/up"/>
 
-        <TextView
-                android:id="@+id/cuc_multi_selection_up_text"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/settings_cuc_upload_to_parent_folder"
-                android:textSize="@dimen/tv_subtitle_txt_size"
-                android:textColor="@color/fancy_gray"
-                android:layout_centerVertical="true"
-                android:layout_toRightOf="@+id/cuc_multi_selection_up_icon"/>
+    <TextView android:id="@+id/cuc_multi_selection_up_text"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:text="@string/settings_cuc_upload_to_parent_folder"
+      android:textSize="@dimen/tv_subtitle_txt_size"
+      android:textColor="@color/fancy_gray"
+      android:layout_centerVertical="true"
+      android:layout_toRightOf="@+id/cuc_multi_selection_up_icon"/>
+  </RelativeLayout>
 
-    </RelativeLayout>
+  <TextView android:id="@+id/cuc_multi_selection_current_directory_txt"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/choose_a_library"
+    android:textSize="@dimen/tv_txt_size"
+    android:padding="10dp"
+    android:layout_below="@+id/cuc_multi_selection_up_layout"/>
 
-    <TextView
-            android:id="@+id/cuc_multi_selection_current_directory_txt"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/choose_a_library"
-            android:textSize="@dimen/tv_txt_size"
-            android:padding="10dp"
-            android:layout_below="@+id/cuc_multi_selection_up_layout"/>
+  <ImageView android:id="@+id/cuc_multi_selection_refresh_iv"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingRight="20dp"
+    android:src="@drawable/refresh"
+    android:layout_alignParentRight="true"
+    android:layout_alignTop="@id/cuc_multi_selection_current_directory_txt"
+    android:layout_below="@+id/cuc_multi_selection_up_layout"/>
 
-    <ImageView
-            android:id="@+id/cuc_multi_selection_refresh_iv"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingRight="20dp"
-            android:src="@drawable/refresh"
-            android:layout_alignParentRight="true"
-            android:layout_alignTop="@id/cuc_multi_selection_current_directory_txt"
-            android:layout_below="@+id/cuc_multi_selection_up_layout"/>
+  <LinearLayout android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="5dp"
+    android:layout_below="@+id/cuc_multi_selection_current_directory_txt"
+    android:orientation="vertical">
 
-    <LinearLayout android:layout_width="match_parent"
-                  android:layout_height="wrap_content"
-                  android:layout_marginTop="5dp"
-                  android:layout_below="@+id/cuc_multi_selection_current_directory_txt"
-                  android:orientation="vertical">
-        <TextView
-                android:id="@+id/cuc_multi_selection_error_msg"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:gravity="center"
-                android:textSize="18sp"
-                android:visibility="gone"/>
-        <TextView
-                android:id="@+id/cuc_multi_selection_empty_msg"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:gravity="center"
-                android:visibility="gone"
-                android:textAppearance="?android:attr/textAppearanceLarge"/>
+    <TextView android:id="@+id/cuc_multi_selection_error_msg"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:gravity="center"
+      android:textSize="18sp"
+      android:visibility="gone"/>
 
-        <LinearLayout android:id="@+id/cuc_multi_selection_list_container"
-                      android:layout_width="match_parent"
-                      android:layout_height="wrap_content"
-                      android:orientation="vertical">
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@drawable/lv_divider_inset"/>
+    <TextView android:id="@+id/cuc_multi_selection_empty_msg"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:gravity="center"
+      android:visibility="gone"
+      android:textAppearance="?android:attr/textAppearanceLarge"/>
 
-            <ListView
-                    android:id="@+id/cuc_multi_selection_lv"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_centerHorizontal="true"
-                    android:divider="@drawable/lv_divider_inset"
-                    android:dividerHeight="@dimen/lv_divider_height"
-                    android:drawSelectorOnTop="true"/>
+    <LinearLayout android:id="@+id/cuc_multi_selection_list_container"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical">
 
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@drawable/lv_divider_inset"/>
+      <View android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@drawable/lv_divider_inset"/>
 
-        </LinearLayout>
+      <ListView android:id="@+id/cuc_multi_selection_lv"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:divider="@drawable/lv_divider_inset"
+        android:dividerHeight="@dimen/lv_divider_height"
+        android:drawSelectorOnTop="true">
+        <!--Removed ObsoleteLayoutParam: layout_centerHorizontal-->
+      </ListView>
 
-        <LinearLayout
-                android:id="@+id/cuc_multi_selection_progress_container"
-                android:orientation="vertical"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:visibility="gone"
-                android:gravity="center">
-
-            <ProgressBar
-                    style="?android:attr/progressBarStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"/>
-            <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:text="@string/settings_cuc_loading"
-                    android:paddingTop="4dip"
-                    android:singleLine="true"/>
-
-        </LinearLayout>
-
+      <View android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@drawable/lv_divider_inset"/>
     </LinearLayout>
 
+    <LinearLayout android:id="@+id/cuc_multi_selection_progress_container"
+      android:orientation="vertical"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:visibility="gone"
+      android:gravity="center">
+
+      <ProgressBar style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+      <TextView android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:text="@string/settings_cuc_loading"
+        android:paddingTop="4dip"
+        android:singleLine="true"/>
+    </LinearLayout>
+  </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/list_item_entry.xml
+++ b/app/src/main/res/layout/list_item_entry.xml
@@ -1,112 +1,100 @@
-<?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:background="?android:selectableItemBackground"
-    android:orientation="vertical">
+<?xml version='1.0' encoding='utf-8'?>
+  <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="fill_parent"
+  android:layout_height="fill_parent"
+  android:background="?android:selectableItemBackground"
+  android:orientation="vertical">
 
-    <RelativeLayout
+  <RelativeLayout android:layout_width="fill_parent"
+    android:layout_height="@dimen/lv_item_height"
+    android:paddingRight="@dimen/lv_item_inset">
+
+    <ImageView android:id="@+id/list_item_multi_select_btn"
+      android:layout_width="@dimen/lv_multi_select_width"
+      android:layout_height="@dimen/lv_multi_select_height"
+      android:layout_alignParentLeft="true"
+      android:layout_centerInParent="true"
+      android:paddingLeft="@dimen/lv_multi_select_padding_left"
+      android:visibility="gone"/>
+
+    <ImageView android:id="@+id/list_item_icon"
+      android:layout_width="@dimen/lv_icon_width"
+      android:layout_height="@dimen/lv_icon_height"
+      android:layout_centerVertical="true"
+      android:layout_toRightOf="@id/list_item_multi_select_btn"
+      android:paddingLeft="@dimen/lv_item_padding_left"/>
+
+    <ImageView android:id="@+id/list_item_space"
+      android:layout_width="@dimen/lv_space_width"
+      android:layout_height="fill_parent"
+      android:layout_toRightOf="@id/list_item_icon"/>
+
+    <LinearLayout android:id="@+id/list_item_txt_group"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_centerVertical="true"
+      android:layout_toLeftOf="@+id/expandable_toggle_button"
+      android:layout_toRightOf="@id/list_item_space"
+      android:orientation="vertical">
+
+      <TextView android:id="@+id/list_item_title"
         android:layout_width="fill_parent"
-        android:layout_height="@dimen/lv_item_height"
-        android:paddingRight="@dimen/lv_item_inset">
+        android:layout_height="wrap_content"
+        android:lines="1"
+        android:singleLine="true"
+        android:textColor="@color/fancy_dark_black"
+        android:textSize="@dimen/lv_title_txt_size"/>
 
-        <ImageView
-            android:id="@+id/list_item_multi_select_btn"
-            android:layout_width="@dimen/lv_multi_select_width"
-            android:layout_height="@dimen/lv_multi_select_height"
-            android:layout_alignParentLeft="true"
-            android:layout_centerInParent="true"
-            android:paddingLeft="@dimen/lv_multi_select_padding_left"
-            android:visibility="gone" />
+      <RelativeLayout android:id="@+id/list_item_subtitle_group"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content">
 
-        <ImageView
-            android:id="@+id/list_item_icon"
-            android:layout_width="@dimen/lv_icon_width"
-            android:layout_height="@dimen/lv_icon_height"
-            android:layout_centerVertical="true"
-            android:layout_toRightOf="@id/list_item_multi_select_btn"
-            android:paddingLeft="@dimen/lv_item_padding_left" />
+        <ImageView android:id="@+id/list_item_download_status_icon"
+          android:layout_width="@dimen/lv_download_icon_width"
+          android:layout_height="@dimen/lv_download_icon_height"
+          android:layout_alignParentLeft="true"
+          android:layout_marginLeft="@dimen/lv_download_icon_margin_left"
+          android:layout_marginRight="@dimen/lv_download_icon_margin_right"
+          android:layout_marginTop="@dimen/lv_download_icon_margin_top"
+          android:contentDescription="@null"
+          android:src="@drawable/list_item_download_finished"
+          android:visibility="gone"/>
 
-        <ImageView
-            android:id="@+id/list_item_space"
-            android:layout_width="@dimen/lv_space_width"
-            android:layout_height="fill_parent"
-            android:layout_toRightOf="@id/list_item_icon" />
+        <ProgressBar android:id="@+id/list_item_download_status_progressbar"
+          android:layout_width="@dimen/lv_download_icon_width"
+          android:layout_height="@dimen/lv_download_icon_height"
+          android:layout_alignParentLeft="true"
+          android:layout_marginLeft="@dimen/lv_download_icon_margin_left"
+          android:layout_marginRight="@dimen/lv_download_icon_margin_right"
+          android:layout_marginTop="@dimen/lv_download_icon_margin_top"
+          android:layout_toRightOf="@id/list_item_download_status_icon"
+          android:visibility="gone"/>
 
-        <LinearLayout
-            android:id="@+id/list_item_txt_group"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:layout_toLeftOf="@+id/expandable_toggle_button"
-            android:layout_toRightOf="@id/list_item_space"
-            android:orientation="vertical">
+        <TextView android:id="@+id/list_item_subtitle"
+          android:layout_width="fill_parent"
+          android:layout_height="wrap_content"
+          android:layout_toRightOf="@id/list_item_download_status_progressbar"
+          android:textColor="@color/fancy_black"
+          android:textSize="@dimen/lv_subtitle_txt_size"/>
+        <!--Removed ObsoleteLayoutParam: layout_alignLeft-->
+        <!--Removed ObsoleteLayoutParam: layout_below-->
+      </RelativeLayout>
+    </LinearLayout>
 
-            <TextView
-                android:id="@+id/list_item_title"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:lines="1"
-                android:singleLine="true"
-                android:textColor="@color/fancy_dark_black"
-                android:textSize="@dimen/lv_title_txt_size" />
+    <RelativeLayout android:id="@+id/expandable_toggle_button"
+      android:layout_width="@dimen/lv_iv_action_width"
+      android:layout_height="fill_parent"
+      android:layout_alignParentEnd="true"
+      android:layout_alignParentRight="true"
+      android:background="@drawable/toggle_btn_selector_holo_light"
+      android:visibility="gone">
 
-            <RelativeLayout
-                android:id="@+id/list_item_subtitle_group"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_alignLeft="@id/list_item_title"
-                android:layout_below="@id/list_item_title">
-
-                <ImageView
-                    android:id="@+id/list_item_download_status_icon"
-                    android:layout_width="@dimen/lv_download_icon_width"
-                    android:layout_height="@dimen/lv_download_icon_height"
-                    android:layout_alignParentLeft="true"
-                    android:layout_marginLeft="@dimen/lv_download_icon_margin_left"
-                    android:layout_marginRight="@dimen/lv_download_icon_margin_right"
-                    android:layout_marginTop="@dimen/lv_download_icon_margin_top"
-                    android:contentDescription="@null"
-                    android:src="@drawable/list_item_download_finished"
-                    android:visibility="gone" />
-
-                <ProgressBar
-                    android:id="@+id/list_item_download_status_progressbar"
-                    android:layout_width="@dimen/lv_download_icon_width"
-                    android:layout_height="@dimen/lv_download_icon_height"
-                    android:layout_alignParentLeft="true"
-                    android:layout_marginLeft="@dimen/lv_download_icon_margin_left"
-                    android:layout_marginRight="@dimen/lv_download_icon_margin_right"
-                    android:layout_marginTop="@dimen/lv_download_icon_margin_top"
-                    android:layout_toRightOf="@id/list_item_download_status_icon"
-                    android:visibility="gone" />
-
-                <TextView
-                    android:id="@+id/list_item_subtitle"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_toRightOf="@id/list_item_download_status_progressbar"
-                    android:textColor="@color/fancy_black"
-                    android:textSize="@dimen/lv_subtitle_txt_size" />
-            </RelativeLayout>
-        </LinearLayout>
-
-        <RelativeLayout
-            android:id="@+id/expandable_toggle_button"
-            android:layout_width="@dimen/lv_iv_action_width"
-            android:layout_height="fill_parent"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:background="@drawable/toggle_btn_selector_holo_light"
-            android:visibility="gone">
-
-            <ImageView
-                android:layout_width="20dp"
-                android:layout_height="20dp"
-                android:layout_alignParentBottom="true"
-                android:layout_alignParentRight="true"
-                android:layout_marginBottom="@dimen/lv_item_padding"
-                android:src="@drawable/spinner_disabled_holo_light" />
-        </RelativeLayout>
+      <ImageView android:layout_width="20dp"
+        android:layout_height="20dp"
+        android:layout_alignParentBottom="true"
+        android:layout_alignParentRight="true"
+        android:layout_marginBottom="@dimen/lv_item_padding"
+        android:src="@drawable/spinner_disabled_holo_light"/>
     </RelativeLayout>
+  </RelativeLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/ppw_history_changes.xml
+++ b/app/src/main/res/layout/ppw_history_changes.xml
@@ -1,33 +1,29 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
+<?xml version='1.0' encoding='utf-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="380dp"
-        android:orientation="vertical"
-        android:background="@color/white"
-        android:layout_alignParentBottom="true">
+  <LinearLayout android:layout_width="match_parent"
+    android:layout_height="380dp"
+    android:orientation="vertical"
+    android:background="@color/white"
+    android:layout_alignParentBottom="true">
 
-        <TextView
-            android:id="@+id/tv_history_changes_title"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/margin_large"
-            android:gravity="left"
-            android:text="@string/history_change_title"
-            android:textColor="@color/grey"
-            android:textSize="@dimen/font_size_bigger" />
+    <TextView android:id="@+id/tv_history_changes_title"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:layout_margin="@dimen/margin_large"
+      android:gravity="left"
+      android:text="@string/history_change_title"
+      android:textColor="@color/grey"
+      android:textSize="@dimen/font_size_bigger"/>
 
-        <ListView
-            android:id="@+id/lv_history_changes"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_below="@id/tv_history_changes_title"
-            android:divider="@color/transparent"
-            android:dividerHeight="0dp">
-
-        </ListView>
-    </LinearLayout>
+    <ListView android:id="@+id/lv_history_changes"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:divider="@color/transparent"
+      android:dividerHeight="0dp">
+      
+        <!--Removed ObsoleteLayoutParam: layout_below--></ListView>
+  </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/starred_list_item.xml
+++ b/app/src/main/res/layout/starred_list_item.xml
@@ -1,65 +1,58 @@
-<?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                android:background="?android:selectableItemBackground"
-                android:layout_width="fill_parent"
-                android:layout_height="@dimen/lv_item_height"
-                android:padding="@dimen/lv_item_padding">
+<?xml version='1.0' encoding='utf-8'?>
+  <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  android:background="?android:selectableItemBackground"
+  android:layout_width="fill_parent"
+  android:layout_height="@dimen/lv_item_height"
+  android:padding="@dimen/lv_item_padding">
 
-    <ImageView
-            android:id="@+id/list_item_multi_select_btn"
-            android:layout_width="@dimen/lv_multi_select_width"
-            android:layout_height="@dimen/lv_multi_select_height"
-            android:paddingLeft="@dimen/lv_multi_select_padding_left"
-            android:layout_alignParentLeft="true"
-            android:layout_centerInParent="true"
-            android:visibility="visible"/>
+  <ImageView android:id="@+id/list_item_multi_select_btn"
+    android:layout_width="@dimen/lv_multi_select_width"
+    android:layout_height="@dimen/lv_multi_select_height"
+    android:paddingLeft="@dimen/lv_multi_select_padding_left"
+    android:layout_alignParentLeft="true"
+    android:layout_centerInParent="true"
+    android:visibility="visible"/>
 
-    <ImageView
-            android:id="@+id/starred_list_item_icon"
-            android:layout_width="@dimen/lv_icon_width"
-            android:layout_height="@dimen/lv_icon_height"
-            android:layout_toRightOf="@id/list_item_multi_select_btn"
-            android:layout_centerVertical="true"/>
+  <ImageView android:id="@+id/starred_list_item_icon"
+    android:layout_width="@dimen/lv_icon_width"
+    android:layout_height="@dimen/lv_icon_height"
+    android:layout_toRightOf="@id/list_item_multi_select_btn"
+    android:layout_centerVertical="true"/>
 
-    <ImageView
-            android:id="@+id/starred_list_item_space"
-            android:layout_width="@dimen/lv_space_width"
-            android:layout_height="fill_parent"
-            android:layout_toRightOf="@id/starred_list_item_icon"/>
+  <ImageView android:id="@+id/starred_list_item_space"
+    android:layout_width="@dimen/lv_space_width"
+    android:layout_height="fill_parent"
+    android:layout_toRightOf="@id/starred_list_item_icon"/>
 
-        <LinearLayout
-                android:id="@+id/starred_list_item_txt_group"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:layout_centerVertical="true"
-                android:layout_toRightOf="@id/starred_list_item_space"
-                android:layout_toLeftOf="@+id/starred_list_item_action">
+  <LinearLayout android:id="@+id/starred_list_item_txt_group"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:layout_centerVertical="true"
+    android:layout_toRightOf="@id/starred_list_item_space"
+    android:layout_toLeftOf="@+id/starred_list_item_action">
 
-                <TextView
-                        android:id="@+id/starred_list_item_title"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:lines="1"
-                        android:singleLine="true"
-                        android:textColor="@color/fancy_dark_black"
-                        android:textSize="@dimen/lv_title_txt_size"/>
+    <TextView android:id="@+id/starred_list_item_title"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:lines="1"
+      android:singleLine="true"
+      android:textColor="@color/fancy_dark_black"
+      android:textSize="@dimen/lv_title_txt_size"/>
 
-                <TextView
-                        android:id="@+id/starred_list_item_subtitle"
-                        android:layout_width="fill_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_below="@id/starred_list_item_title"
-                        android:textColor="@color/fancy_black"
-                        android:textSize="@dimen/lv_subtitle_txt_size"/>
-        </LinearLayout>
+    <TextView android:id="@+id/starred_list_item_subtitle"
+      android:layout_width="fill_parent"
+      android:layout_height="wrap_content"
+      android:textColor="@color/fancy_black"
+      android:textSize="@dimen/lv_subtitle_txt_size">
+      <!--Removed ObsoleteLayoutParam: layout_below-->
+    </TextView>
+  </LinearLayout>
 
-        <ImageView
-            android:id="@+id/starred_list_item_action"
-            android:layout_width="@dimen/lv_iv_action_width"
-            android:layout_height="fill_parent"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"/>
-
+  <ImageView android:id="@+id/starred_list_item_action"
+    android:layout_width="@dimen/lv_iv_action_width"
+    android:layout_height="fill_parent"
+    android:layout_alignParentEnd="true"
+    android:layout_alignParentRight="true"
+    android:layout_centerVertical="true"/>
 </RelativeLayout>


### PR DESCRIPTION
Hi (again),

I am developing a tool to automatically refactor Android applications with the goal of improving energy efficiency.
This pull request has the changes generated while applying the rule "ObsoleteLayoutParam".

While developing your application's views you might be specifying attributes in a view's artefact that are not necessary due to the nature of its parent. In this PR, those attributes were replaced by a comment.

I have made a previous validation of the changes and they seem correct.
Unfortunately, this tool is not able keep the original whitespace of the files, so comparison without ignoring whitespace might be confusing.
Please consider the changes and let me know if you agree with them.

Best,
Luis