### PR TITLE
Use new version of BottomSheet, fixes issue #713

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,7 +99,7 @@ android {
         compile 'commons-io:commons-io:2.4'
         compile 'com.google.guava:guava:18.0'
         compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.3'
-        compile 'com.cocosw:bottomsheet:1.3.0'
+        compile 'com.cocosw:bottomsheet:1.3.1'
         compile 'us.feras.mdv:markdownview:1.1.0'
         compile 'com.commit451:PhotoView:1.2.4'
         compile 'com.joanzapata.iconify:android-iconify-material-community:2.2.1'


### PR DESCRIPTION
I have an issue with the app crashing when I try to access context menu of any file/folder or library. Using newer version of the BottomSheet dependency fixes the problem. Tested on emulated Nexus 5X with Android 7.0 and 8.0 and on physical device Nexus 5X with android 8.0