### PR TITLE
Allow user added CAs

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
         android:name="com.seafile.seadroid2.SeadroidApplication"
         android:label="@string/app_name"
         android:theme="@style/AppTheme"
-        android:icon="@drawable/ic_launcher">
+        android:icon="@drawable/ic_launcher"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <activity android:name="com.seafile.seadroid2.ui.activity.AccountsActivity"
                   android:launchMode="singleTop"

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <!-- Trust preinstalled CAs -->
+            <certificates src="system"/>
+            <!-- Additionally trust user added CAs -->
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
This allows user added CAs to work with Seadroid, letting users (among other things) establish a secure channel for local domains (impossible without this change). 

Exact same changes as in [nextcloud/android@727375642d4357486ce0fd3f4f4f2a80999f34fa](https://github.com/nextcloud/android/commit/727375642d4357486ce0fd3f4f4f2a80999f34fa)

Discussion thread: [[BUG] Valid personal certificate detected as invalid on seadroid](https://forum.seafile.com/t/bug-valid-personal-certificate-detected-as-invalid-on-seadroid/6373)