### PR TITLE
Fixed bugs when setting FILE_SERVER_ROOT='/seafhttp'

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/SeafConnection.java
+++ b/app/src/main/java/com/seafile/seadroid2/SeafConnection.java
@@ -58,7 +58,6 @@ public class SeafConnection {
     private static final String DEBUG_TAG = "SeafConnection";
     private static final int CONNECTION_TIMEOUT = 15000;
     private static final int READ_TIMEOUT = 30000;
-
     private Account account;
 
     public SeafConnection(Account act) {
@@ -460,14 +459,17 @@ public class SeafConnection {
 
             String result = new String(req.bytes(), "UTF-8");
             String fileID = req.header("oid");
-
             // should return "\"http://gonggeng.org:8082/...\"" or "\"https://gonggeng.org:8082/...\"
-            if (result.startsWith("\"http") && fileID != null) {
-                String url = result.substring(1, result.length() - 1);
-                return new Pair<String, String>(url, fileID);
+            if (result.startsWith("\"/") && fileID != null) {
+                result = account.server+result.substring(2,result.length() - 1);
+            } 
+            else if (result.startsWith("\"http") && fileID != null) {
+                result = result.substring(1, result.length() - 1);
             } else {
                 throw SeafException.illFormatException;
             }
+            String url = result;
+            return new Pair<String, String>(url, fileID);
         } catch (SeafException e) {
             throw e;
         } catch (UnsupportedEncodingException e) {
@@ -781,11 +783,15 @@ public class SeafConnection {
 
             String result = new String(req.bytes(), "UTF-8");
             // should return "\"http://gonggeng.org:8082/...\"" or "\"https://gonggeng.org:8082/...\"
-            if (result.startsWith("\"http")) {
+            if (result.startsWith("\"/")) {
+                return account.server+result.substring(2,result.length() - 1);
+            } 
+            else if (result.startsWith("\"http")) {
                 // remove the starting and trailing quote
                 return result.substring(1, result.length() - 1);
-            } else
+            } else {
                 throw SeafException.unknownException;
+            }
         } catch (SeafException e) {
             Log.d(DEBUG_TAG, e.getCode() + e.getMessage());
             throw e;


### PR DESCRIPTION
The good reason for setting `FILE_SERVER_ROOT='/seafhttp'`  (rather than specify the hostname like `http://192.168.1.111/seafhttp` or `http://my-seafile-server.com/seafhttp` ) is that we can access the files whether we are in the local network or outside it.

It works fine for browsers, but not for this android app.    
Now I found the problem and fixed it.   

***
Actually I find many people deploying their private seafile server locally but they do not  have a public ip, sometimes people are even in a network of multiple layers of routers. So this instruction [Deploy Seafile behind NAT](https://manual-cn.seafile.com/deploy/deploy_seafile_behind_nat.html) is not always practicable. Alternatively, `frp` or `ngrok` is a popular choice that allows people exposing their local servers behind a NAT or firewall to the internet. 

However, if we simply set `FILE_SERVER_ROOT=http://ngrok-remote-ip/seafhttp`, then even we are in the local network, when we upload or download files, it'll take a huge detour and severely affects the network transfer speed (`frp` or `ngrok` work in a different mechanism and do not have a function similar to `NAT loopback`).  This is why enabling `FILE_SERVER_ROOT='/seafhttp'` can be super helpful.
