### PR TITLE
Fixed travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ android:
       - android-27
       - extra-android-support
       - extra-android-m2repository
+
+# License agreement workaround
+# From similar issue: https://travis-ci.community/t/accept-license-for-android-build-tools-27-0-3-bug/549
+before_install:
+  - yes | sdkmanager "build-tools;28.0.3"
+
 # https://docs.travis-ci.com/user/languages/android/#Caching
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
```
A problem occurred configuring project ':app'.
> Failed to install the following Android SDK packages as some licences have not been accepted.
     build-tools;28.0.3 Android SDK Build-Tools 28.0.3
```
This issue might come from Travis because we are not using Build-Tools version '28.0.3' but '27.0.3'
I read a workaround on the travis community:
https://travis-ci.community/t/accept-license-for-android-build-tools-27-0-3-bug/549
