### PR TITLE
Do not use GalleryBucket if name is null

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/cameraupload/GalleryBucketUtils.java
+++ b/app/src/main/java/com/seafile/seadroid2/cameraupload/GalleryBucketUtils.java
@@ -84,9 +84,9 @@ public class GalleryBucketUtils {
                 MediaStore.Video.Media.BUCKET_DISPLAY_NAME,
         };
         Cursor cursor = context.getContentResolver().query(images,
-                projection,            // Which columns to return
+                projection, // Which columns to return
                 null,       // Which rows to return (all rows)
-                null,                  // Selection arguments (none)
+                null,       // Selection arguments (none)
                 null        // Ordering
         );
 
@@ -102,11 +102,15 @@ public class GalleryBucketUtils {
             Bucket b = new Bucket();
             b.id = cursor.getString(bucketIdColumnIndex);
             b.name = cursor.getString(bucketColumnIndex);
-            String video_id = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Video.Media._ID));
-            b.videoId = video_id;
+            b.videoId = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Video.Media._ID));
+
+            if (b.name == null) {
+                continue;
+            }
+            
             b.isCameraBucket = false;
             for (String name : CAMERA_BUCKET_NAMES) {
-                if (b.name != null && b.name.equalsIgnoreCase(name)) {
+                if (b.name.equalsIgnoreCase(name)) {
                     b.isCameraBucket = true;
                 }
             }
@@ -126,9 +130,9 @@ public class GalleryBucketUtils {
         };
 
         Cursor cursor = context.getContentResolver().query(images,
-                projection,            // Which columns to return
+                projection, // Which columns to return
                 null,       // Which rows to return (all rows)
-                null,                  // Selection arguments (none)
+                null,       // Selection arguments (none)
                 null        // Ordering
         );
 
@@ -144,12 +148,16 @@ public class GalleryBucketUtils {
             Bucket b = new Bucket();
             b.id = cursor.getString(bucketIdColumnIndex);
             b.name = cursor.getString(bucketColumnIndex);
-            String image_id = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID));
-            b.imageId = image_id;
+            b.imageId = cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID));
+           
+            if (b.name == null) {
+                continue;
+            }
+
             b.isCameraBucket = false;
             b.isImages = GalleryBucketUtils.IMAGES;
             for (String name : CAMERA_BUCKET_NAMES) {
-                if (b.name != null && b.name.equalsIgnoreCase(name)) {
+                if (b.name.equalsIgnoreCase(name)) {
                     b.isCameraBucket = true;
                 }
             }


### PR DESCRIPTION
Fixes #874
Fixes #893 

cursor.getString returning a null name caused the application to crash in the hashCode override function:
```
E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.hashCode()' on a null object reference
E AndroidRuntime: 	at com.seafile.seadroid2.cameraupload.GalleryBucketUtils$Bucket.hashCode(GalleryBucketUtils.java:51)
```

Reproduced and fix tested on Android 11.

Maybe more null checks should be added as defense in depth against different framework implementations, but I did not want to modify the existing logic more than necessary for my test to work.