### PR TITLE
Add CHACHA20_POLY1305 to the ssl cipher list

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/ssl/SSLSeafileSocketFactory.java
+++ b/app/src/main/java/com/seafile/seadroid2/ssl/SSLSeafileSocketFactory.java
@@ -121,6 +121,7 @@ public class SSLSeafileSocketFactory extends SSLSocketFactory {
                     "DHE-RSA-AES128-SHA",
                     "DHE-RSA-AES256-SHA",
                     "DHE-DSS-AES128-SHA",
+                    "DHE-RSA-CHACHA20-POLY1305",
                     "AES128-SHA",
                     "AES256-SHA"
             };
@@ -137,6 +138,11 @@ public class SSLSeafileSocketFactory extends SSLSocketFactory {
                     "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
                     "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
                     "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+
+                    // ChaCha20 support for servers without AES hardware
+                    // acceleration (eg. Raspberry Pi 4)
+                    "TLS_CHACHA20_POLY1305_SHA256",
+                    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
 
                     // backward compatibility. offers no forward security.
                     "TLS_RSA_WITH_AES_128_CBC_SHA",


### PR DESCRIPTION
Following from #903. TLDR: ChaCha20 is much faster for devices that do not provide hardware AES acceleration (eg. Raspberry Pi 4), and secure to the point of being included in TLS1.3. [The Mozilla Wiki provides a list](https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29) of secure cipher suites, and the ones added here are listed there as secure.