### PR TITLE
Fix travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ android:
   components:
       - tools
       - platform-tools
-      - build-tools-28.0.3
-      - android-27
+      - build-tools-29.0.2
+      - android-29
       - extra-android-support
       - extra-android-m2repository
 
 # License agreement workaround
 # From similar issue: https://travis-ci.community/t/accept-license-for-android-build-tools-27-0-3-bug/549
 before_install:
-  - yes | sdkmanager "build-tools;28.0.3"
+  - yes | sdkmanager "build-tools;29.0.2"
 
 # https://docs.travis-ci.com/user/languages/android/#Caching
 before_cache:


### PR DESCRIPTION
Travis was broken because of this:
``` 
Checking the license for package Android SDK Build-Tools 29.0.2 in /usr/local/android-sdk/licenses

Warning: License for package Android SDK Build-Tools 29.0.2 not accepted.

Checking the license for package Android SDK Platform 29 in /usr/local/android-sdk/licenses

Warning: License for package Android SDK Platform 29 not accepted.

FAILURE: Build failed with an exception
```