### PR TITLE
Added asciidoc file extensions to open with plain text editor

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/util/Utils.java
+++ b/app/src/main/java/com/seafile/seadroid2/util/Utils.java
@@ -753,7 +753,7 @@ public class Utils {
     public static boolean isTextMimeType(String fileName) {
         String suffix = fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase();
         //file is markdown or  txt
-        String[] array = {"ac", "am", "bat", "c", "cc", "cmake", "conf", "cpp", "cs", "css", "csv", "diff",
+        String[] array = {"ac", "adoc", "asciidoc", "am", "bat", "c", "cc", "cmake", "conf", "cpp", "cs", "css", "csv", "diff",
                 "el", "go", "groovy", "h", "htm", "html", "java", "js", "json", "less", "log", "make",
                 "markdown", "md", "org", "patch", "pde", "php", "pl", "properties", "py", "rb", "rst",
                 "sc", "scala", "scd", "schelp", "script", "sh", "sql", "text", "tex", "txt", "vi", "vim",


### PR DESCRIPTION
I've added `adoc` and `asciidoc` to be file extension that cause the plain text editor to open.

This would be really convenient to view and edit asciidoc files on mobile.