### PR TITLE
Fix download progress percetange being always zero

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/notification/DownloadNotificationProvider.java
+++ b/app/src/main/java/com/seafile/seadroid2/notification/DownloadNotificationProvider.java
@@ -3,16 +3,13 @@ package com.seafile.seadroid2.notification;
 import android.app.Notification;
 import android.app.PendingIntent;
 import android.content.Intent;
-import android.util.Log;
 
 import com.seafile.seadroid2.R;
 import com.seafile.seadroid2.SeadroidApplication;
-import com.seafile.seadroid2.transfer.DownloadTask;
 import com.seafile.seadroid2.transfer.DownloadTaskInfo;
 import com.seafile.seadroid2.transfer.DownloadTaskManager;
 import com.seafile.seadroid2.transfer.TaskState;
 import com.seafile.seadroid2.transfer.TransferService;
-import com.seafile.seadroid2.transfer.UploadTaskInfo;
 import com.seafile.seadroid2.ui.CustomNotificationBuilder;
 import com.seafile.seadroid2.ui.activity.TransferActivity;
 

--- a/app/src/main/java/com/seafile/seadroid2/notification/DownloadNotificationProvider.java
+++ b/app/src/main/java/com/seafile/seadroid2/notification/DownloadNotificationProvider.java
@@ -3,13 +3,16 @@ package com.seafile.seadroid2.notification;
 import android.app.Notification;
 import android.app.PendingIntent;
 import android.content.Intent;
+import android.util.Log;
 
 import com.seafile.seadroid2.R;
 import com.seafile.seadroid2.SeadroidApplication;
+import com.seafile.seadroid2.transfer.DownloadTask;
 import com.seafile.seadroid2.transfer.DownloadTaskInfo;
 import com.seafile.seadroid2.transfer.DownloadTaskManager;
 import com.seafile.seadroid2.transfer.TaskState;
 import com.seafile.seadroid2.transfer.TransferService;
+import com.seafile.seadroid2.transfer.UploadTaskInfo;
 import com.seafile.seadroid2.ui.CustomNotificationBuilder;
 import com.seafile.seadroid2.ui.activity.TransferActivity;
 
@@ -124,23 +127,24 @@ public class DownloadNotificationProvider extends BaseNotificationProvider {
 
     @Override
     protected int getProgress() {
-        long downloadedSize = 0l;
-        long totalSize = 0l;
         if (txService == null)
             return 0;
 
+        int total = 0;
+        int finished = 0;
+
         List<DownloadTaskInfo> infos = txService.getAllDownloadTaskInfos();
+
         for (DownloadTaskInfo info : infos) {
             if (info == null)
                 continue;
-            downloadedSize += info.finished;
-            totalSize += info.fileSize;
+
+            total++;
+            if(info.state.equals(TaskState.FINISHED))
+                finished++;
         }
 
-        // avoid ArithmeticException
-        if (totalSize == 0l)
-            return 0;
-        return (int) (downloadedSize * 100 / totalSize);
+        return (int)(finished * 100 / total);
     }
 
 }


### PR DESCRIPTION
This PR changes how the percentage is being calculated. 

It moves from couting processed/remaining total bytes to counting just tasks.

This fixes an issue, where you would be downloading 10 files, first 9 would be 1MB of size and the last one would be 1GB and the percentage would remain at zero untill the last big file starts downloading. With this PR its gonna be at 90% before the last big file starts downloading.

The optimal notification should show more info, but that's for the next time. Example of advanced notification info
![Screenshot_20230214_005534_Smart Launcher](https://user-images.githubusercontent.com/10332247/218601271-156f3348-2f7b-4981-96a7-8ab67f36d51e.jpg)
