### PR TITLE
Fix "disallowed_useragent" Error when using Google OAUTH2 SSO

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/account/ui/SingleSignOnAuthorizeActivity.java
+++ b/app/src/main/java/com/seafile/seadroid2/account/ui/SingleSignOnAuthorizeActivity.java
@@ -63,6 +63,7 @@ public class SingleSignOnAuthorizeActivity extends BaseActivity implements Toolb
 
         mWebview.getSettings().setLoadsImagesAutomatically(true);
         mWebview.getSettings().setJavaScriptEnabled(true);
+        mWebview.getSettings().setUserAgentString(System.getProperty("http.agent"));
         mWebview.setScrollBarStyle(View.SCROLLBARS_INSIDE_OVERLAY);
 
         CustomWebviewClient client = new CustomWebviewClient();


### PR DESCRIPTION
This PR is very similar to haiwen/seafile-iOS#356 which would fix `Error 403: disallowed_useragent` when using Google OAUTH2 for Single Sign-On.

The system's user-agent is used before requesting the page which solves this problem.

This also fixes #783.