### PR TITLE
feat: Bidirectional Folder Sync with Configurable Rules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -221,6 +221,7 @@ android {
         implementation 'androidx.core:core-splashscreen:1.0.1'
         implementation "androidx.appcompat:appcompat:1.7.1"
         implementation "androidx.activity:activity:1.10.1"
+        implementation "androidx.documentfile:documentfile:1.0.1"
         implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
         implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
         implementation "androidx.preference:preference:1.2.1"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -156,6 +156,7 @@
         <activity android:name=".ui.transfer_list.TransferActivity" />
         <activity android:name=".ui.BugHandlerActivity" />
         <activity android:name=".ui.settings.SettingsAlbumBackupAdvancedActivity" />
+        <activity android:name=".ui.folder_sync.FolderSyncFilesActivity" />
         <activity android:name=".ui.data_migrate.DataMigrationV303Activity" />
         <activity android:name=".ui.sdoc.SDocWebViewActivity" />
         <activity

--- a/app/src/main/java/com/seafile/seadroid2/enums/FeatureDataSource.java
+++ b/app/src/main/java/com/seafile/seadroid2/enums/FeatureDataSource.java
@@ -6,12 +6,13 @@ public enum FeatureDataSource {
     DOWNLOAD,
     MANUAL_FILE_UPLOAD,
     SHARE_FILE_TO_SEAFILE,
-    AUTO_UPDATE_LOCAL_FILE;
+    AUTO_UPDATE_LOCAL_FILE,
+    FOLDER_SYNC;
 
     public static TransferDataSource toTransferDataSource(FeatureDataSource transferDataSource) {
         return switch (transferDataSource) {
             case ALBUM_BACKUP -> TransferDataSource.ALBUM_BACKUP;
-            case FOLDER_BACKUP -> TransferDataSource.FOLDER_BACKUP;
+            case FOLDER_BACKUP, FOLDER_SYNC -> TransferDataSource.FOLDER_BACKUP;
             case DOWNLOAD, AUTO_UPDATE_LOCAL_FILE -> TransferDataSource.DOWNLOAD;
             case MANUAL_FILE_UPLOAD, SHARE_FILE_TO_SEAFILE -> TransferDataSource.FILE_BACKUP;
         };

--- a/app/src/main/java/com/seafile/seadroid2/framework/datastore/SyncExclusionManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/datastore/SyncExclusionManager.java
@@ -1,0 +1,99 @@
+package com.seafile.seadroid2.framework.datastore;
+
+import com.seafile.seadroid2.framework.datastore.sp.SettingsManager;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Manages per-file exclusions for each sync rule. When a user unchecks
+ * a file in the per-file toggle UI, its relative path is stored here.
+ * Excluded files are not downloaded and are deleted locally if present.
+ * New server files are NOT in the exclusion set (i.e. they are auto-included).
+ */
+public class SyncExclusionManager {
+    private static final Object sLock = new Object();
+    private static final String KEY_PREFIX = SettingsManager.PKG + ".sync_exclusions.";
+
+    /** Returns the set of excluded relative paths for the given rule. */
+    public static Set<String> getExcludedFiles(String ruleId) {
+        synchronized (sLock) {
+            String json = DataStoreManager.getCommonSharePreference()
+                    .readString(KEY_PREFIX + ruleId);
+            return parseSet(json);
+        }
+    }
+
+    /** Overwrite the full exclusion set for a rule. */
+    public static void setExcludedFiles(String ruleId, Set<String> paths) {
+        synchronized (sLock) {
+            JSONArray arr = new JSONArray();
+            for (String p : paths) {
+                arr.put(p);
+            }
+            DataStoreManager.getCommonSharePreference()
+                    .writeString(KEY_PREFIX + ruleId, arr.toString());
+        }
+    }
+
+    /** Add a single file to the exclusion set. */
+    public static void excludeFile(String ruleId, String relativePath) {
+        synchronized (sLock) {
+            Set<String> set = getExcludedFilesInternal(ruleId);
+            set.add(relativePath);
+            persist(ruleId, set);
+        }
+    }
+
+    /** Remove a single file from the exclusion set (re-include it). */
+    public static void includeFile(String ruleId, String relativePath) {
+        synchronized (sLock) {
+            Set<String> set = getExcludedFilesInternal(ruleId);
+            set.remove(relativePath);
+            persist(ruleId, set);
+        }
+    }
+
+    /** Clear exclusions when a sync rule is deleted. */
+    public static void clearForRule(String ruleId) {
+        synchronized (sLock) {
+            DataStoreManager.getCommonSharePreference()
+                    .writeString(KEY_PREFIX + ruleId, "");
+        }
+    }
+
+    // Internal helpers (caller must hold sLock)
+
+    private static Set<String> getExcludedFilesInternal(String ruleId) {
+        String json = DataStoreManager.getCommonSharePreference()
+                .readString(KEY_PREFIX + ruleId);
+        return parseSet(json);
+    }
+
+    private static void persist(String ruleId, Set<String> set) {
+        JSONArray arr = new JSONArray();
+        for (String p : set) {
+            arr.put(p);
+        }
+        DataStoreManager.getCommonSharePreference()
+                .writeString(KEY_PREFIX + ruleId, arr.toString());
+    }
+
+    private static Set<String> parseSet(String json) {
+        Set<String> result = new HashSet<>();
+        if (json == null || json.isEmpty()) {
+            return result;
+        }
+        try {
+            JSONArray arr = new JSONArray(json);
+            for (int i = 0; i < arr.length(); i++) {
+                result.add(arr.getString(i));
+            }
+        } catch (JSONException ignored) {
+        }
+        return result;
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/framework/datastore/SyncRule.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/datastore/SyncRule.java
@@ -1,0 +1,178 @@
+package com.seafile.seadroid2.framework.datastore;
+
+import android.text.TextUtils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Represents a sync mapping from a Seafile repo/folder to a local Android folder.
+ */
+public class SyncRule {
+    public String id;
+    public String repoId;
+    public String repoName;
+    public String remotePath;  // path within repo, "/" for root
+    public String localUri;    // SAF tree URI string
+    public String localName;   // display name for the local folder
+    public boolean enabled;
+
+    /** Maximum file size in bytes to sync. 0 = unlimited. */
+    public long maxFileSize;
+
+    /**
+     * Comma-separated list of file extensions (without leading dot).
+     * e.g. "mp3,flac,wav". Empty string = no filter.
+     */
+    public String extensionFilter;
+
+    /** "include" means only sync matching extensions; "exclude" means skip them. */
+    public String filterMode; // "include" or "exclude"
+
+    public SyncRule() {
+        this.id = UUID.randomUUID().toString();
+        this.enabled = true;
+        this.maxFileSize = 0;
+        this.extensionFilter = "";
+        this.filterMode = "include";
+    }
+
+    public SyncRule(String repoId, String repoName,
+            String remotePath, String localUri, String localName) {
+        this.id = UUID.randomUUID().toString();
+        this.repoId = repoId;
+        this.repoName = repoName;
+        this.remotePath = remotePath;
+        this.localUri = localUri;
+        this.localName = localName;
+        this.enabled = true;
+        this.maxFileSize = 0;
+        this.extensionFilter = "";
+        this.filterMode = "include";
+    }
+
+    public JSONObject toJson() throws JSONException {
+        JSONObject obj = new JSONObject();
+        obj.put("id", id);
+        obj.put("repoId", repoId);
+        obj.put("repoName", repoName);
+        obj.put("remotePath", remotePath);
+        obj.put("localUri", localUri);
+        obj.put("localName", localName);
+        obj.put("enabled", enabled);
+        obj.put("maxFileSize", maxFileSize);
+        obj.put("extensionFilter", extensionFilter);
+        obj.put("filterMode", filterMode);
+        return obj;
+    }
+
+    public static SyncRule fromJson(JSONObject obj) throws JSONException {
+        SyncRule rule = new SyncRule();
+        rule.id = obj.getString("id");
+        rule.repoId = obj.getString("repoId");
+        rule.repoName = obj.getString("repoName");
+        rule.remotePath = obj.getString("remotePath");
+        rule.localUri = obj.getString("localUri");
+        rule.localName = obj.optString("localName", "");
+        rule.enabled = obj.optBoolean("enabled", true);
+        rule.maxFileSize = obj.optLong("maxFileSize", 0);
+        rule.extensionFilter = obj.optString("extensionFilter", "");
+        rule.filterMode = obj.optString("filterMode", "include");
+        return rule;
+    }
+
+    /**
+     * Check if a file should be excluded based on rule-level filters
+     * (max size and extension filter). Does NOT check per-file exclusions.
+     *
+     * @param fileName the file name (e.g. "song.mp3")
+     * @param fileSize the file size in bytes
+     * @return true if the file should be excluded from sync
+     */
+    public boolean isFilteredOut(String fileName, long fileSize) {
+        // Check size limit
+        if (maxFileSize > 0 && fileSize > maxFileSize) {
+            return true;
+        }
+
+        // Check extension filter
+        if (!TextUtils.isEmpty(extensionFilter) && fileName != null) {
+            String ext = getFileExtension(fileName);
+            String[] allowed = extensionFilter.toLowerCase(Locale.US).split(",");
+            boolean matchesFilter = false;
+            for (String a : allowed) {
+                if (a.trim().equals(ext)) {
+                    matchesFilter = true;
+                    break;
+                }
+            }
+            if ("include".equals(filterMode)) {
+                // Include mode: only sync matching extensions
+                return !matchesFilter;
+            } else {
+                // Exclude mode: skip matching extensions
+                return matchesFilter;
+            }
+        }
+        return false;
+    }
+
+    private static String getFileExtension(String fileName) {
+        int dot = fileName.lastIndexOf('.');
+        if (dot >= 0 && dot < fileName.length() - 1) {
+            return fileName.substring(dot + 1).toLowerCase(Locale.US);
+        }
+        return "";
+    }
+
+    /**
+     * Check if a given repo/path falls within this sync rule's scope.
+     * A file matches if it's in the same repo and under the rule's remote path.
+     */
+    public boolean matches(String fileRepoId, String filePath) {
+        if (!enabled || repoId == null || fileRepoId == null
+                || remotePath == null) {
+            return false;
+        }
+        if (!repoId.equals(fileRepoId)) {
+            return false;
+        }
+        if ("/".equals(remotePath)) {
+            return true;
+        }
+        String normalizedRemote = remotePath.endsWith("/") ? remotePath : remotePath + "/";
+        return filePath.startsWith(normalizedRemote) || filePath.equals(remotePath);
+    }
+
+    /**
+     * Returns the relative path of the file within this sync rule's scope.
+     * For example, if remotePath is "/Documents/" and filePath is "/Documents/work/report.pdf",
+     * this returns "work/report.pdf".
+     */
+    public String getRelativePath(String filePath) {
+        if ("/".equals(remotePath)) {
+            return filePath.startsWith("/") ? filePath.substring(1) : filePath;
+        }
+        String normalizedRemote = remotePath.endsWith("/") ? remotePath : remotePath + "/";
+        if (filePath.startsWith(normalizedRemote)) {
+            return filePath.substring(normalizedRemote.length());
+        }
+        // File is at the root of the sync path
+        int lastSlash = filePath.lastIndexOf('/');
+        if (lastSlash >= 0) {
+            return filePath.substring(lastSlash + 1);
+        }
+        return filePath;
+    }
+
+    public String getDisplaySummary() {
+        String remote = repoName;
+        if (remotePath != null && !"/".equals(remotePath)) {
+            remote += remotePath;
+        }
+        return remote + " → " + (localName != null && !localName.isEmpty() ? localName : "...");
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/framework/datastore/SyncRuleManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/datastore/SyncRuleManager.java
@@ -1,0 +1,125 @@
+package com.seafile.seadroid2.framework.datastore;
+
+import android.text.TextUtils;
+
+import com.seafile.seadroid2.framework.datastore.sp.SettingsManager;
+import com.seafile.seadroid2.framework.util.SLogs;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages persistence and lookup of folder sync rules.
+ * Rules are stored as a JSON array in SharedPreferences.
+ */
+public class SyncRuleManager {
+    private static final String TAG = "SyncRuleManager";
+    private static final Object sLock = new Object();
+
+    public static List<SyncRule> getAll() {
+        synchronized (sLock) {
+            String json = DataStoreManager.getCommonSharePreference()
+                    .readString(SettingsManager.SHARED_PREF_SYNC_RULES);
+            return parseRules(json);
+        }
+    }
+
+    public static void saveAll(List<SyncRule> rules) {
+        synchronized (sLock) {
+            try {
+                JSONArray arr = new JSONArray();
+                for (SyncRule rule : rules) {
+                    arr.put(rule.toJson());
+                }
+                DataStoreManager.getCommonSharePreference()
+                        .writeString(
+                                SettingsManager.SHARED_PREF_SYNC_RULES,
+                                arr.toString());
+            } catch (JSONException e) {
+                SLogs.e(TAG, "Failed to save sync rules: "
+                        + e.getMessage());
+            }
+        }
+    }
+
+    public static void add(SyncRule rule) {
+        synchronized (sLock) {
+            List<SyncRule> rules = getAll();
+            rules.add(rule);
+            saveAll(rules);
+        }
+    }
+
+    public static void remove(String ruleId) {
+        synchronized (sLock) {
+            List<SyncRule> rules = getAll();
+            rules.removeIf(r -> r.id.equals(ruleId));
+            saveAll(rules);
+        }
+        SyncStateManager.clearForRule(ruleId);
+        SyncExclusionManager.clearForRule(ruleId);
+    }
+
+    public static void update(SyncRule updated) {
+        synchronized (sLock) {
+            List<SyncRule> rules = getAll();
+            for (int i = 0; i < rules.size(); i++) {
+                if (rules.get(i).id.equals(updated.id)) {
+                    rules.set(i, updated);
+                    break;
+                }
+            }
+            saveAll(rules);
+        }
+    }
+
+    /** Find a sync rule by its ID. Returns null if not found. */
+    public static SyncRule findById(String ruleId) {
+        List<SyncRule> rules = getAll();
+        for (SyncRule rule : rules) {
+            if (rule.id.equals(ruleId)) {
+                return rule;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Find the best matching sync rule for a given file download.
+     * If multiple rules match, returns the most specific one (longest remotePath).
+     */
+    public static SyncRule findMatch(String repoId, String filePath) {
+        List<SyncRule> rules = getAll();
+        SyncRule best = null;
+        for (SyncRule rule : rules) {
+            if (rule.matches(repoId, filePath)) {
+                if (best == null
+                        || (rule.remotePath != null
+                        && rule.remotePath.length()
+                        > best.remotePath.length())) {
+                    best = rule;
+                }
+            }
+        }
+        return best;
+    }
+
+    private static List<SyncRule> parseRules(String json) {
+        List<SyncRule> rules = new ArrayList<>();
+        if (TextUtils.isEmpty(json)) {
+            return rules;
+        }
+        try {
+            JSONArray arr = new JSONArray(json);
+            for (int i = 0; i < arr.length(); i++) {
+                rules.add(SyncRule.fromJson(arr.getJSONObject(i)));
+            }
+        } catch (JSONException e) {
+            SLogs.e(TAG, "Failed to parse sync rules: " + e.getMessage());
+        }
+        return rules;
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/framework/datastore/SyncStateManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/datastore/SyncStateManager.java
@@ -1,0 +1,118 @@
+package com.seafile.seadroid2.framework.datastore;
+
+import android.text.TextUtils;
+
+import com.seafile.seadroid2.framework.datastore.sp.SettingsManager;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tracks the set of file relative paths that were successfully synced for
+ * each sync rule. Used to distinguish "new remote file" from "locally deleted
+ * file" during bidirectional sync.
+ */
+public class SyncStateManager {
+    private static final Object sLock = new Object();
+
+    /** Returns the set of relative paths last synced for the given rule. */
+    public static Set<String> getSyncedFiles(String ruleId) {
+        synchronized (sLock) {
+            String key = SettingsManager.SHARED_PREF_SYNC_STATE_PREFIX
+                    + ruleId;
+            String json = DataStoreManager.getCommonSharePreference()
+                    .readString(key);
+            return parseSet(json);
+        }
+    }
+
+    /**
+     * Atomically persists the sync state after a sync cycle completes.
+     *
+     * <p>Because download/upload threads call {@link #addSyncedFile} while
+     * the sync worker is building {@code newState}, a plain overwrite would
+     * stomp those concurrent writes. This method detects entries added since
+     * the cycle started (present in persisted state but absent from the
+     * snapshot taken at the start of the cycle) and preserves them.
+     *
+     * @param ruleId        the sync rule ID
+     * @param previousState the snapshot from {@link #getSyncedFiles} at cycle start
+     * @param newState      the computed set of currently-synced files
+     */
+    public static void setSyncedFiles(
+            String ruleId, Set<String> previousState, Set<String> newState) {
+        synchronized (sLock) {
+            String key = SettingsManager.SHARED_PREF_SYNC_STATE_PREFIX
+                    + ruleId;
+            // Find entries added by concurrent transfers since the cycle
+            // started (present now but were NOT in the snapshot)
+            String persisted = DataStoreManager.getCommonSharePreference()
+                    .readString(key);
+            Set<String> current = parseSet(persisted);
+            Set<String> concurrentAdds = new HashSet<>(current);
+            concurrentAdds.removeAll(previousState);
+
+            // Final state = cycle result + concurrent additions
+            Set<String> merged = new HashSet<>(newState);
+            merged.addAll(concurrentAdds);
+
+            JSONArray arr = new JSONArray();
+            for (String p : merged) {
+                arr.put(p);
+            }
+            DataStoreManager.getCommonSharePreference()
+                    .writeString(key, arr.toString());
+        }
+    }
+
+    /** Removes persisted sync state for a deleted rule. */
+    public static void clearForRule(String ruleId) {
+        synchronized (sLock) {
+            String key = SettingsManager.SHARED_PREF_SYNC_STATE_PREFIX
+                    + ruleId;
+            DataStoreManager.getCommonSharePreference()
+                    .writeString(key, "");
+        }
+    }
+
+    /**
+     * Record a single file as synced. Called when a download completes
+     * and the file lands on local disk, so the sync state is populated
+     * immediately rather than waiting for the next sync cycle.
+     */
+    public static void addSyncedFile(String ruleId, String relativePath) {
+        synchronized (sLock) {
+            String key = SettingsManager.SHARED_PREF_SYNC_STATE_PREFIX
+                    + ruleId;
+            String json = DataStoreManager.getCommonSharePreference()
+                    .readString(key);
+            Set<String> files = parseSet(json);
+            files.add(relativePath);
+            JSONArray arr = new JSONArray();
+            for (String p : files) {
+                arr.put(p);
+            }
+            DataStoreManager.getCommonSharePreference()
+                    .writeString(key, arr.toString());
+        }
+    }
+
+    private static Set<String> parseSet(String json) {
+        Set<String> result = new HashSet<>();
+        if (TextUtils.isEmpty(json)) {
+            return result;
+        }
+        try {
+            JSONArray arr = new JSONArray(json);
+            for (int i = 0; i < arr.length(); i++) {
+                result.add(arr.getString(i));
+            }
+        } catch (JSONException ignored) {
+            // Corrupted data — start fresh
+        }
+        return result;
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/framework/datastore/sp/SettingsManager.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/datastore/sp/SettingsManager.java
@@ -31,6 +31,9 @@ public final class SettingsManager {
     public static final String PKG = "com.seafile.seadroid2";
 
     public static final String SHARED_PREF_STORAGE_DIR = PKG + ".storageId";
+    public static final String SHARED_PREF_DOWNLOAD_DIRECTORY = PKG + ".download_directory";
+    public static final String SHARED_PREF_SYNC_RULES = PKG + ".sync_rules";
+    public static final String SHARED_PREF_SYNC_STATE_PREFIX = PKG + ".sync_state.";
     public static final String SHARED_PREF_CUSTOM_STORAGE_DIR = PKG + ".custom_storage_dir";
 
     public static final String SHARED_PREF_CAMERA_UPLOAD_REPO_ID = PKG + ".camera.repoid";

--- a/app/src/main/java/com/seafile/seadroid2/framework/notification/FolderSyncNotificationHelper.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/notification/FolderSyncNotificationHelper.java
@@ -1,0 +1,50 @@
+package com.seafile.seadroid2.framework.notification;
+
+import static com.seafile.seadroid2.framework.notification.base.NotificationUtils.NOTIFICATION_MESSAGE_KEY;
+import static com.seafile.seadroid2.framework.notification.base.NotificationUtils.NOTIFICATION_OPEN_UPLOAD_TAB;
+
+import android.content.Context;
+import android.content.Intent;
+
+import com.seafile.seadroid2.R;
+import com.seafile.seadroid2.framework.notification.base.BaseTransferNotificationHelper;
+import com.seafile.seadroid2.framework.notification.base.NotificationUtils;
+import com.seafile.seadroid2.ui.transfer_list.TransferActivity;
+
+public class FolderSyncNotificationHelper extends BaseTransferNotificationHelper {
+    public FolderSyncNotificationHelper(Context context) {
+        super(context);
+    }
+
+    @Override
+    public Intent getTransferIntent() {
+        Intent dIntent = new Intent(context, TransferActivity.class);
+        dIntent.putExtra(NOTIFICATION_MESSAGE_KEY, NOTIFICATION_OPEN_UPLOAD_TAB);
+        return dIntent;
+    }
+
+    @Override
+    public String getDefaultTitle() {
+        return context.getString(R.string.settings_folder_sync_title);
+    }
+
+    @Override
+    public String getDefaultSubtitle() {
+        return context.getString(R.string.settings_folder_sync_syncing);
+    }
+
+    @Override
+    public int getMaxProgress() {
+        return 100;
+    }
+
+    @Override
+    public String getChannelId() {
+        return NotificationUtils.FILE_TRANSFER_CHANNEL;
+    }
+
+    @Override
+    public int getNotificationId() {
+        return NotificationUtils.NID_FOLDER_SYNC;
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/framework/notification/base/NotificationUtils.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/notification/base/NotificationUtils.java
@@ -41,6 +41,9 @@ public class NotificationUtils {
     //download
     public static final int NID_FILE_DOWNLOAD = 3400;
 
+    //folder sync
+    public static final int NID_FOLDER_SYNC = 3500;
+
 
     public static final String NOTIFICATION_MESSAGE_KEY = "notification_key";
     public static final String NOTIFICATION_OPEN_UPLOAD_TAB = "open_upload_tab_notification";

--- a/app/src/main/java/com/seafile/seadroid2/framework/service/BackupThreadExecutor.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/service/BackupThreadExecutor.java
@@ -13,6 +13,7 @@ import com.seafile.seadroid2.framework.service.download.FileDownloader;
 import com.seafile.seadroid2.framework.service.upload.FileUploader;
 import com.seafile.seadroid2.framework.service.upload.FolderBackupScanner;
 import com.seafile.seadroid2.framework.service.upload.FolderBackupUploader;
+import com.seafile.seadroid2.framework.service.upload.FolderSyncUploader;
 import com.seafile.seadroid2.framework.service.upload.LocalFileUpdater;
 import com.seafile.seadroid2.framework.service.upload.MediaBackupScanner;
 import com.seafile.seadroid2.framework.service.upload.MediaBackupUploader;
@@ -47,6 +48,7 @@ public class BackupThreadExecutor {
             ShareToSeafileUploader shareToSeafileUploader = new ShareToSeafileUploader(getApplicationContext(), notificationDispatcher);
             FileDownloader downloader = new FileDownloader(getApplicationContext(), notificationDispatcher);
             LocalFileUpdater localFileUpdater = new LocalFileUpdater(getApplicationContext(), notificationDispatcher);
+            FolderSyncUploader folderSyncUploader = new FolderSyncUploader(getApplicationContext(), notificationDispatcher);
 
             transmitterMap.put(FeatureDataSource.MANUAL_FILE_UPLOAD, fileUploader);
             transmitterMap.put(FeatureDataSource.ALBUM_BACKUP, mediaBackupUploader);
@@ -54,6 +56,7 @@ public class BackupThreadExecutor {
             transmitterMap.put(FeatureDataSource.DOWNLOAD, downloader);
             transmitterMap.put(FeatureDataSource.AUTO_UPDATE_LOCAL_FILE, localFileUpdater);
             transmitterMap.put(FeatureDataSource.SHARE_FILE_TO_SEAFILE, shareToSeafileUploader);
+            transmitterMap.put(FeatureDataSource.FOLDER_SYNC, folderSyncUploader);
         }
     }
 
@@ -92,6 +95,7 @@ public class BackupThreadExecutor {
     private CompletableFuture<Void> albumBackupFuture;
     private CompletableFuture<Void> localFileUpdateFuture;
     private CompletableFuture<Void> shareFileUploadFuture;
+    private CompletableFuture<Void> folderSyncUploadFuture;
 
     public boolean isFolderBackupRunning() {
         return folderBackupFuture != null && !folderBackupFuture.isDone();
@@ -106,7 +110,8 @@ public class BackupThreadExecutor {
                 || (shareFileUploadFuture != null && !shareFileUploadFuture.isDone())
                 || (localFileUpdateFuture != null && !localFileUpdateFuture.isDone())
                 || (folderBackupFuture != null && !folderBackupFuture.isDone())
-                || (albumBackupFuture != null && !albumBackupFuture.isDone());
+                || (albumBackupFuture != null && !albumBackupFuture.isDone())
+                || (folderSyncUploadFuture != null && !folderSyncUploadFuture.isDone());
     }
     public boolean isDownloading(){
         return fileDownloadFuture != null && !fileDownloadFuture.isDone();
@@ -119,9 +124,18 @@ public class BackupThreadExecutor {
         stopLocalFileUpdate();
         stopShareToSeafileUpload();
         stopDownload();
+        stopFolderSyncUpload();
 
         // clear all notification
         notificationDispatcher.clearDelay();
+    }
+
+    private void stopFolderSyncUpload() {
+        FolderSyncUploader uploader = getTransmitter(
+                FeatureDataSource.FOLDER_SYNC);
+        if (uploader != null) {
+            uploader.stop();
+        }
     }
 
     public void stopSpecialTransmitter(String modelId, FeatureDataSource dataSource) {
@@ -141,11 +155,18 @@ public class BackupThreadExecutor {
         } else if (FeatureDataSource.DOWNLOAD == dataSource) {
             FileDownloader fileDownloader = getTransmitter(FeatureDataSource.DOWNLOAD);
             fileDownloader.stopById(modelId);
+        } else if (FeatureDataSource.FOLDER_SYNC == dataSource) {
+            FolderSyncUploader folderSyncUploader = getTransmitter(FeatureDataSource.FOLDER_SYNC);
+            folderSyncUploader.stopById(modelId);
         } else {
             throw new RuntimeException("You must provide a valid data source.");
         }
 
         SafeLogs.d(TAG, "stopById()", "stopped: " + modelId);
+    }
+
+    public boolean isFolderSyncUploading() {
+        return folderSyncUploadFuture != null && !folderSyncUploadFuture.isDone();
     }
 
     public void stopDownload() {
@@ -155,6 +176,11 @@ public class BackupThreadExecutor {
     }
 
     public void runDownloadTask() {
+        if (fileDownloadFuture != null && !fileDownloadFuture.isDone()) {
+            SafeLogs.d(TAG, "runDownloadTask()", "download task is already running, skip");
+            return;
+        }
+
         fileDownloadFuture = runTask(new Runnable() {
             @Override
             public void run() {
@@ -171,6 +197,32 @@ public class BackupThreadExecutor {
             @Override
             public void run() {
                 fileDownloadFuture = null;
+            }
+        });
+    }
+
+    public void runFolderSyncUploadTask() {
+        if (folderSyncUploadFuture != null && !folderSyncUploadFuture.isDone()) {
+            SafeLogs.d(TAG, "runFolderSyncUploadTask()", "upload task is already running, skip");
+            return;
+        }
+
+        folderSyncUploadFuture = runTask(new Runnable() {
+            @Override
+            public void run() {
+                FolderSyncUploader uploader = getTransmitter(FeatureDataSource.FOLDER_SYNC);
+                SeafException seafException = uploader.upload();
+
+                if (seafException != SeafException.SUCCESS) {
+                    SafeLogs.d(TAG, "runFolderSyncUploadTask()", "upload error: " + seafException);
+                } else {
+                    SafeLogs.d(TAG, "runFolderSyncUploadTask()", "upload success");
+                }
+            }
+        }, new Runnable() {
+            @Override
+            public void run() {
+                folderSyncUploadFuture = null;
             }
         });
     }

--- a/app/src/main/java/com/seafile/seadroid2/framework/service/BackupThreadNotificationDispatcher.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/service/BackupThreadNotificationDispatcher.java
@@ -59,7 +59,7 @@ public class BackupThreadNotificationDispatcher implements ITransferNotification
 
         return switch (source) {
             case ALBUM_BACKUP -> context.getString(R.string.settings_camera_upload_info_title);
-            case FOLDER_BACKUP -> context.getString(R.string.settings_folder_backup_info_title);
+            case FOLDER_BACKUP, FOLDER_SYNC -> context.getString(R.string.settings_folder_backup_info_title);
             case MANUAL_FILE_UPLOAD, SHARE_FILE_TO_SEAFILE, AUTO_UPDATE_LOCAL_FILE ->
                     context.getString(R.string.channel_name_upload);
             case DOWNLOAD -> context.getString(R.string.download);
@@ -91,6 +91,11 @@ public class BackupThreadNotificationDispatcher implements ITransferNotification
             case DOWNLOAD: {
                 dIntent = new Intent(context, TransferActivity.class);
                 dIntent.putExtra(NOTIFICATION_MESSAGE_KEY, NOTIFICATION_OPEN_DOWNLOAD_TAB);
+                dIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            }
+            case FOLDER_SYNC: {
+                dIntent = new Intent(context, TransferActivity.class);
+                dIntent.putExtra(NOTIFICATION_MESSAGE_KEY, NOTIFICATION_OPEN_UPLOAD_TAB);
                 dIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             }
         }

--- a/app/src/main/java/com/seafile/seadroid2/framework/service/ForegroundServiceNotificationDispatcher.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/service/ForegroundServiceNotificationDispatcher.java
@@ -66,7 +66,7 @@ public class ForegroundServiceNotificationDispatcher implements ITransferNotific
 
         return switch (source) {
             case ALBUM_BACKUP -> context.getString(R.string.settings_camera_upload_info_title);
-            case FOLDER_BACKUP -> context.getString(R.string.settings_folder_backup_info_title);
+            case FOLDER_BACKUP, FOLDER_SYNC -> context.getString(R.string.settings_folder_backup_info_title);
             case MANUAL_FILE_UPLOAD, SHARE_FILE_TO_SEAFILE, AUTO_UPDATE_LOCAL_FILE ->
                     context.getString(R.string.channel_name_upload);
             case DOWNLOAD -> context.getString(R.string.download);
@@ -79,7 +79,7 @@ public class ForegroundServiceNotificationDispatcher implements ITransferNotific
         }
 
         return switch (source) {
-            case ALBUM_BACKUP, FOLDER_BACKUP -> context.getString(R.string.backing_up);
+            case ALBUM_BACKUP, FOLDER_BACKUP, FOLDER_SYNC -> context.getString(R.string.backing_up);
             case MANUAL_FILE_UPLOAD, SHARE_FILE_TO_SEAFILE, AUTO_UPDATE_LOCAL_FILE ->
                     context.getString(R.string.notification_upload_started_title);
             case DOWNLOAD -> context.getString(R.string.notification_download_started_title);
@@ -112,6 +112,11 @@ public class ForegroundServiceNotificationDispatcher implements ITransferNotific
             case DOWNLOAD: {
                 dIntent = new Intent(context, TransferActivity.class);
                 dIntent.putExtra(NOTIFICATION_MESSAGE_KEY, NOTIFICATION_OPEN_DOWNLOAD_TAB);
+                dIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            }
+            case FOLDER_SYNC: {
+                dIntent = new Intent(context, TransferActivity.class);
+                dIntent.putExtra(NOTIFICATION_MESSAGE_KEY, NOTIFICATION_OPEN_UPLOAD_TAB);
                 dIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             }
         }

--- a/app/src/main/java/com/seafile/seadroid2/framework/service/ParentEventDownloader.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/service/ParentEventDownloader.java
@@ -1,10 +1,13 @@
 package com.seafile.seadroid2.framework.service;
 
 import android.content.Context;
+import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Pair;
+import android.webkit.MimeTypeMap;
 
 import androidx.annotation.NonNull;
+import androidx.documentfile.provider.DocumentFile;
 
 import com.blankj.utilcode.util.CloneUtils;
 import com.blankj.utilcode.util.CollectionUtils;
@@ -19,6 +22,9 @@ import com.seafile.seadroid2.enums.TransferResult;
 import com.seafile.seadroid2.enums.TransferStatus;
 import com.seafile.seadroid2.framework.crypto.SecurePasswordManager;
 import com.seafile.seadroid2.framework.datastore.DataManager;
+import com.seafile.seadroid2.framework.datastore.SyncRule;
+import com.seafile.seadroid2.framework.datastore.SyncRuleManager;
+import com.seafile.seadroid2.framework.datastore.SyncStateManager;
 import com.seafile.seadroid2.framework.datastore.sp.SettingsManager;
 import com.seafile.seadroid2.framework.db.AppDatabase;
 import com.seafile.seadroid2.framework.db.entities.EncKeyCacheEntity;
@@ -37,12 +43,16 @@ import com.seafile.seadroid2.ui.file.FileService;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -400,13 +410,120 @@ public abstract class ParentEventDownloader extends ParentEventTransfer {
             }
 
             //important
-            Path path = java.nio.file.Files.move(tempFile.toPath(), localFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-            boolean isSuccess = path.toFile().exists();
-            if (isSuccess) {
-                java.nio.file.Files.deleteIfExists(tempFile.toPath());
-                updateToSuccess(fileId, localFile);
+            // Check if this file matches a sync rule
+            SyncRule syncRule = SyncRuleManager.findMatch(currentTransferModel.repo_id, currentTransferModel.full_path);
+
+            if (syncRule != null) {
+                // Move file to the user's chosen sync destination (not a copy)
+                boolean moved = moveToSyncDestination(tempFile, syncRule, currentTransferModel.full_path);
+                if (moved) {
+                    // Record in sync state immediately so delete
+                    // propagation works on the very next sync cycle
+                    String relPath = syncRule.getRelativePath(
+                            currentTransferModel.full_path);
+                    SyncStateManager.addSyncedFile(
+                            syncRule.id, relPath);
+
+                    Files.deleteIfExists(tempFile.toPath());
+                    updateToSuccess(fileId, localFile);
+                } else {
+                    // Fallback to normal cache if sync dest fails
+                    SafeLogs.d(TAG, "download()", "Sync dest failed, falling back to cache");
+                    Path path = Files.move(tempFile.toPath(), localFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    if (path.toFile().exists()) {
+                        Files.deleteIfExists(tempFile.toPath());
+                        updateToSuccess(fileId, localFile);
+                    }
+                }
+            } else {
+                // No sync rule — normal cache behavior
+                Path path = Files.move(tempFile.toPath(), localFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                boolean isSuccess = path.toFile().exists();
+                if (isSuccess) {
+                    Files.deleteIfExists(tempFile.toPath());
+                    updateToSuccess(fileId, localFile);
+                }
             }
         }
+    }
+
+    /**
+     * Moves a temp file to the sync destination folder using SAF.
+     * Creates subdirectories as needed to preserve the relative path structure.
+     * Returns true on success.
+     */
+    private boolean moveToSyncDestination(File tempFile, SyncRule rule, String fullPath) {
+        try {
+            Uri treeUri = Uri.parse(rule.localUri);
+            DocumentFile destDir = DocumentFile.fromTreeUri(getContext(), treeUri);
+            if (destDir == null || !destDir.exists() || !destDir.canWrite()) {
+                SafeLogs.d(TAG, "moveToSyncDestination()", "Sync destination not accessible");
+                return false;
+            }
+
+            // Create subdirectories for the relative path
+            String relativePath = rule.getRelativePath(fullPath);
+            String[] parts = relativePath.split("/");
+            String fileName = parts[parts.length - 1];
+
+            // Navigate/create intermediate directories
+            DocumentFile currentDir = destDir;
+            for (int i = 0; i < parts.length - 1; i++) {
+                String dirName = parts[i];
+                if (dirName.isEmpty()) continue;
+                DocumentFile subDir = currentDir.findFile(dirName);
+                if (subDir == null || !subDir.isDirectory()) {
+                    subDir = currentDir.createDirectory(dirName);
+                }
+                if (subDir == null) {
+                    SafeLogs.d(TAG, "moveToSyncDestination()", "Failed to create subdirectory: " + dirName);
+                    return false;
+                }
+                currentDir = subDir;
+            }
+
+            // Remove existing file with same name
+            DocumentFile existingFile = currentDir.findFile(fileName);
+            if (existingFile != null) {
+                existingFile.delete();
+            }
+
+            DocumentFile newFile = currentDir.createFile(
+                    getMimeType(fileName), fileName);
+            if (newFile == null) {
+                SafeLogs.d(TAG, "moveToSyncDestination()", "Failed to create file");
+                return false;
+            }
+
+            try (InputStream in = new FileInputStream(tempFile);
+                 OutputStream out = getContext().getContentResolver().openOutputStream(newFile.getUri())) {
+                if (out == null) {
+                    return false;
+                }
+                byte[] buffer = new byte[SEGMENT_SIZE];
+                int bytesRead;
+                while ((bytesRead = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, bytesRead);
+                }
+            }
+
+            SafeLogs.d(TAG, "moveToSyncDestination()", "Moved to sync dest: " + fileName);
+            return true;
+        } catch (IOException e) {
+            SafeLogs.e(TAG, "Failed to move to sync dest: " + e.getMessage());
+            return false;
+        }
+    }
+
+    private static String getMimeType(String fileName) {
+        String ext = MimeTypeMap.getFileExtensionFromUrl(
+                Uri.encode(fileName));
+        if (ext != null) {
+            String mime = MimeTypeMap.getSingleton()
+                    .getMimeTypeFromExtension(ext.toLowerCase());
+            if (mime != null) return mime;
+        }
+        return "application/octet-stream";
     }
 
     public boolean isRetry(SeafException result) {

--- a/app/src/main/java/com/seafile/seadroid2/framework/service/upload/FolderSyncUploader.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/service/upload/FolderSyncUploader.java
@@ -1,0 +1,132 @@
+package com.seafile.seadroid2.framework.service.upload;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+import com.blankj.utilcode.util.NetworkUtils;
+import com.seafile.seadroid2.R;
+import com.seafile.seadroid2.SeafException;
+import com.seafile.seadroid2.account.Account;
+import com.seafile.seadroid2.account.SupportAccountManager;
+import com.seafile.seadroid2.enums.FeatureDataSource;
+import com.seafile.seadroid2.framework.datastore.SyncRule;
+import com.seafile.seadroid2.framework.datastore.SyncRuleManager;
+import com.seafile.seadroid2.framework.datastore.SyncStateManager;
+import com.seafile.seadroid2.framework.service.ITransferNotification;
+import com.seafile.seadroid2.framework.service.ParentEventUploader;
+import com.seafile.seadroid2.framework.util.SafeLogs;
+import com.seafile.seadroid2.framework.util.Toasts;
+import com.seafile.seadroid2.framework.worker.GlobalTransferCacheList;
+import com.seafile.seadroid2.framework.worker.TransferEvent;
+import com.seafile.seadroid2.framework.worker.queue.TransferModel;
+
+/**
+ * Handles uploading of local-only files to Seafile as part of folder sync.
+ * Picks transfer models from the FOLDER_SYNC_QUEUE.
+ */
+public class FolderSyncUploader extends ParentEventUploader {
+    private final String TAG = "FolderSyncUploader";
+
+    public FolderSyncUploader(Context context, ITransferNotification i) {
+        super(context, i);
+    }
+
+    @Override
+    public FeatureDataSource getFeatureDataSource() {
+        return FeatureDataSource.FOLDER_SYNC;
+    }
+
+    public void stop() {
+        SafeLogs.d(TAG, "stop()");
+        GlobalTransferCacheList.FOLDER_SYNC_QUEUE.clear();
+        stopThis();
+        send(FeatureDataSource.FOLDER_SYNC, TransferEvent.EVENT_TRANSFER_TASK_CANCELLED);
+    }
+
+    public void stopById(String modelId) {
+        SafeLogs.d(TAG, "stopById()", "stop upload by id: " + modelId);
+        TransferModel transferModel = getCurrentTransferringModel();
+        if (transferModel == null) return;
+        if (!TextUtils.equals(modelId, transferModel.getId())) {
+            GlobalTransferCacheList.FOLDER_SYNC_QUEUE.remove(modelId);
+            return;
+        }
+        stopThis();
+    }
+
+    public SeafException upload() {
+        SafeLogs.d(TAG, "start folder sync upload");
+        send(FeatureDataSource.FOLDER_SYNC, TransferEvent.EVENT_TRANSFER_TASK_START);
+
+        Account account = SupportAccountManager.getInstance().getCurrentAccount();
+        if (account == null) {
+            SafeLogs.d(TAG, "account is null");
+            return returnSuccess();
+        }
+
+        if (!NetworkUtils.isConnected()) {
+            SafeLogs.d(TAG, "network is not connected");
+            return returnSuccess();
+        }
+
+        int totalPendingCount = GlobalTransferCacheList.FOLDER_SYNC_QUEUE.getPendingCount();
+        if (totalPendingCount <= 0) {
+            SafeLogs.d(TAG, "folder sync upload queue is empty");
+            return returnSuccess();
+        }
+
+        SafeLogs.d(TAG, "pending count: " + totalPendingCount);
+
+        SeafException resultException = SeafException.SUCCESS;
+        SeafException interruptException = SeafException.SUCCESS;
+        SeafException lastException = SeafException.SUCCESS;
+
+        while (true) {
+            TransferModel transferModel = GlobalTransferCacheList.FOLDER_SYNC_QUEUE.pick();
+            if (transferModel == null) break;
+
+            try {
+                transfer(account, transferModel);
+
+                // Upload succeeded — record in sync state immediately
+                SyncRule rule = SyncRuleManager.findMatch(
+                        transferModel.repo_id,
+                        transferModel.target_path);
+                if (rule != null) {
+                    String relPath = rule.getRelativePath(
+                            transferModel.target_path);
+                    SyncStateManager.addSyncedFile(rule.id, relPath);
+                }
+            } catch (SeafException seafException) {
+                boolean isInterrupt = isInterrupt(seafException);
+                if (isInterrupt) {
+                    SafeLogs.e("Folder sync upload interrupted");
+                    notifyError(seafException);
+                    interruptException = seafException;
+                    break;
+                } else {
+                    lastException = seafException;
+                    SafeLogs.e("Folder sync upload error, continuing next");
+                }
+            }
+        }
+
+        getTransferNotificationDispatcher().clearDelay();
+
+        if (interruptException != SeafException.SUCCESS) {
+            resultException = interruptException;
+        } else if (totalPendingCount == 1 && lastException != SeafException.SUCCESS) {
+            resultException = lastException;
+        }
+
+        sendCompleteEvent(FeatureDataSource.FOLDER_SYNC, 
+                resultException != SeafException.SUCCESS ? resultException.getMessage() : null,
+                totalPendingCount);
+        return resultException;
+    }
+
+    protected SeafException returnSuccess() {
+        send(FeatureDataSource.FOLDER_SYNC, TransferEvent.EVENT_TRANSFER_TASK_COMPLETE);
+        return SeafException.SUCCESS;
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/framework/worker/BackgroundJobManagerImpl.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/worker/BackgroundJobManagerImpl.java
@@ -242,4 +242,51 @@ public class BackgroundJobManagerImpl {
     public void cancelAllJobs() {
         getWorkManager().cancelAllWork();
     }
+
+
+    /// /////////////////// folder sync //////////////////////
+
+    public void scheduleFolderSync() {
+        SLogs.d(TAG, "scheduleFolderSync()");
+
+        Constraints constraints = new Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build();
+
+        PeriodicWorkRequest request = periodicRequestBuilder(FolderSyncWorker.class)
+                .setId(FolderSyncWorker.UID)
+                .setConstraints(constraints)
+                .setInitialDelay(DEFAULT_PERIODIC_JOB_INTERVAL_MINUTES, TimeUnit.MINUTES)
+                .build();
+
+        getWorkManager().enqueueUniquePeriodicWork(
+                FolderSyncWorker.TAG,
+                ExistingPeriodicWorkPolicy.KEEP,
+                request
+        );
+    }
+
+    public void stopFolderSync() {
+        SLogs.d(TAG, "stopFolderSync()");
+        getWorkManager().cancelUniqueWork(FolderSyncWorker.TAG);
+        getWorkManager().pruneWork();
+    }
+
+    public void runFolderSyncNow() {
+        SLogs.d(TAG, "runFolderSyncNow()");
+
+        Constraints constraints = new Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .build();
+
+        OneTimeWorkRequest request = oneTimeRequestBuilder(FolderSyncWorker.class)
+                .setConstraints(constraints)
+                .build();
+
+        getWorkManager().enqueueUniqueWork(
+                FolderSyncWorker.TAG + "_once",
+                ExistingWorkPolicy.KEEP,
+                request
+        );
+    }
 }

--- a/app/src/main/java/com/seafile/seadroid2/framework/worker/FolderSyncWorker.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/worker/FolderSyncWorker.java
@@ -1,0 +1,530 @@
+package com.seafile.seadroid2.framework.worker;
+
+import android.app.ForegroundServiceStartNotAllowedException;
+import android.content.Context;
+import android.net.Uri;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.documentfile.provider.DocumentFile;
+import androidx.work.ForegroundInfo;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import com.blankj.utilcode.util.NetworkUtils;
+import com.seafile.seadroid2.account.Account;
+import com.seafile.seadroid2.account.SupportAccountManager;
+import com.seafile.seadroid2.enums.FeatureDataSource;
+import com.seafile.seadroid2.enums.SaveTo;
+import com.seafile.seadroid2.enums.TransferStatus;
+import com.seafile.seadroid2.framework.datastore.DataManager;
+import com.seafile.seadroid2.framework.datastore.SyncExclusionManager;
+import com.seafile.seadroid2.framework.datastore.SyncRule;
+import com.seafile.seadroid2.framework.datastore.SyncRuleManager;
+import com.seafile.seadroid2.framework.datastore.SyncStateManager;
+import com.seafile.seadroid2.framework.http.HttpIO;
+import com.seafile.seadroid2.framework.model.dirents.DeleteDirentModel;
+import com.seafile.seadroid2.framework.model.dirents.DirentRecursiveFileModel;
+import com.seafile.seadroid2.framework.notification.FolderSyncNotificationHelper;
+import com.seafile.seadroid2.framework.service.BackupThreadExecutor;
+import com.seafile.seadroid2.framework.util.SafeLogs;
+import com.seafile.seadroid2.framework.util.SLogs;
+import com.seafile.seadroid2.framework.util.Utils;
+import com.seafile.seadroid2.framework.worker.queue.TransferModel;
+import com.seafile.seadroid2.ui.file.FileService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Periodic background worker that syncs files bidirectionally between
+ * Seafile repo folders and local Android folders based on configured sync rules.
+ */
+public class FolderSyncWorker extends Worker {
+    public static final String TAG = "FolderSyncWorker";
+    public static final UUID UID = UUID.nameUUIDFromBytes(TAG.getBytes());
+
+    private final FolderSyncNotificationHelper notificationHelper;
+
+    public FolderSyncWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
+        super(context, workerParams);
+        notificationHelper = new FolderSyncNotificationHelper(context);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        SafeLogs.d(TAG, "Folder sync worker started");
+
+        Account account = SupportAccountManager.getInstance().getCurrentAccount();
+        if (account == null) {
+            SafeLogs.d(TAG, "No account logged in");
+            return Result.success();
+        }
+
+        if (!NetworkUtils.isConnected()) {
+            SafeLogs.d(TAG, "No network connection");
+            return Result.success();
+        }
+
+        List<SyncRule> rules = SyncRuleManager.getAll();
+        if (rules.isEmpty()) {
+            SafeLogs.d(TAG, "No sync rules configured");
+            return Result.success();
+        }
+
+        int downloadCount = 0;
+        int uploadCount = 0;
+
+        for (SyncRule rule : rules) {
+            if (!rule.enabled) continue;
+
+            try {
+                int[] counts = processRule(account, rule);
+                downloadCount += counts[0];
+                uploadCount += counts[1];
+            } catch (Exception e) {
+                SafeLogs.e(TAG, "Error processing sync rule: "
+                        + rule.getDisplaySummary() + " - " + e.getMessage());
+            }
+        }
+
+        SafeLogs.d(TAG, "Sync scan complete. Downloads: "
+                + downloadCount + ", Uploads: " + uploadCount);
+
+        if (downloadCount == 0 && uploadCount == 0) {
+            return Result.success();
+        }
+
+        // Promote to foreground service so Android keeps the process alive
+        showForegroundNotification();
+
+        // Kick off download and upload tasks
+        if (downloadCount > 0) {
+            BackupThreadExecutor.getInstance().runDownloadTask();
+        }
+        if (uploadCount > 0) {
+            BackupThreadExecutor.getInstance().runFolderSyncUploadTask();
+        }
+
+        // Wait for transfers to finish (keeps the Worker alive)
+        waitForTransfersComplete();
+
+        SafeLogs.d(TAG, "Folder sync transfers complete");
+        return Result.success();
+    }
+
+    /**
+     * Promote this Worker to a foreground service with a persistent notification.
+     * This prevents Android from killing the process during long transfers.
+     */
+    private void showForegroundNotification() {
+        try {
+            ForegroundInfo foregroundInfo = notificationHelper.getForegroundNotification();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                try {
+                    setForegroundAsync(foregroundInfo);
+                } catch (ForegroundServiceStartNotAllowedException e) {
+                    SLogs.e("Cannot start foreground service: " + e.getMessage());
+                }
+            } else {
+                setForegroundAsync(foregroundInfo);
+            }
+        } catch (Exception e) {
+            SafeLogs.e(TAG, "Failed to show foreground notification: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Block until both downloads and uploads triggered by this sync cycle are done.
+     * Polls every 2 seconds, respecting Worker cancellation via {@link #isStopped()}.
+     */
+    private void waitForTransfersComplete() {
+        while (!isStopped()) {
+            boolean downloading = BackupThreadExecutor.getInstance().isDownloading();
+            boolean uploading = BackupThreadExecutor.getInstance().isFolderSyncUploading();
+            if (!downloading && !uploading) {
+                break;
+            }
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+    }
+
+    /**
+     * Process a single sync rule using 4-way comparison with sync state index.
+     *
+     * <p>The sync state tracks files that were previously synced. This lets us
+     * distinguish "new server file" from "user deleted locally":
+     * <ul>
+     *   <li>On server + in previous state + NOT local → local delete → delete from server</li>
+     *   <li>On server + NOT in previous state → new file → download</li>
+     *   <li>Local + in previous state + NOT on server → server delete → delete locally</li>
+     *   <li>Local + NOT in previous state → new file → upload</li>
+     * </ul>
+     *
+     * @return int[]{downloadCount, uploadCount}
+     */
+    private int[] processRule(Account account, SyncRule rule) throws IOException {
+        // 1. Fetch remote file list recursively
+        List<DirentRecursiveFileModel> remoteFiles =
+                fetchRemoteFiles(rule.repoId, rule.remotePath);
+
+        // 2. Scan local folder via SAF
+        Uri treeUri = Uri.parse(rule.localUri);
+        DocumentFile localRoot;
+        try {
+            localRoot = DocumentFile.fromTreeUri(
+                    getApplicationContext(), treeUri);
+        } catch (SecurityException e) {
+            SafeLogs.e(TAG, "SAF permission revoked for rule: "
+                    + rule.getDisplaySummary());
+            return new int[]{0, 0};
+        }
+        if (localRoot == null || !localRoot.exists()) {
+            SafeLogs.d(TAG, "Local folder not accessible for rule: "
+                    + rule.getDisplaySummary());
+            return new int[]{0, 0};
+        }
+
+        // Build sets of relative paths for comparison
+        Map<String, DirentRecursiveFileModel> remoteMap = new HashMap<>();
+        for (DirentRecursiveFileModel rf : remoteFiles) {
+            String fullPath = rf.getParent_dir() + rf.name;
+            String relativePath = rule.getRelativePath(fullPath);
+            remoteMap.put(relativePath, rf);
+        }
+
+        Map<String, DocumentFile> localMap = new HashMap<>();
+        scanLocalFiles(localRoot, "", localMap);
+
+        // 3. Load the previously-synced file index and per-file exclusions
+        Set<String> previousState =
+                SyncStateManager.getSyncedFiles(rule.id);
+        Set<String> exclusions =
+                SyncExclusionManager.getExcludedFiles(rule.id);
+        Set<String> newState = new HashSet<>();
+
+        // Remove already-queued downloads for files that are now excluded
+        // (per-file exclusions or rule-level filters)
+        GlobalTransferCacheList.DOWNLOAD_QUEUE.removeIf(tm -> {
+            if (!rule.repoId.equals(tm.repo_id) || tm.full_path == null) {
+                return false;
+            }
+            String rel = rule.getRelativePath(tm.full_path);
+            return exclusions.contains(rel)
+                    || rule.isFilteredOut(tm.file_name, tm.file_size);
+        });
+
+        int downloadCount = 0;
+        int uploadCount = 0;
+
+        // 4a. Files on server
+        Set<String> deletedRemotePaths = new HashSet<>();
+        for (Map.Entry<String, DirentRecursiveFileModel> entry
+                : remoteMap.entrySet()) {
+            String rel = entry.getKey();
+            DirentRecursiveFileModel rf = entry.getValue();
+            boolean isLocal = localMap.containsKey(rel);
+            boolean wasSynced = previousState.contains(rel);
+
+            // Check if file is excluded by rule-level filters or per-file exclusion
+            boolean isExcluded = exclusions.contains(rel)
+                    || rule.isFilteredOut(rf.name, rf.size);
+
+            if (isExcluded) {
+                // File is excluded — if it exists locally, delete it
+                if (isLocal) {
+                    deleteLocalFile(localRoot, rel);
+                    SafeLogs.d(TAG, "Deleted excluded file locally: " + rel);
+                }
+                // Do NOT add to newState and do NOT propagate delete to server
+                continue;
+            }
+
+            if (isLocal) {
+                // In sync — keep in state
+                newState.add(rel);
+            } else if (wasSynced) {
+                // Was synced before but user deleted locally → propagate
+                boolean deleted = deleteRemoteFile(
+                        rule.repoId, rule.remotePath, rel);
+                if (deleted) {
+                    deletedRemotePaths.add(rel);
+                } else {
+                    // Keep in state to retry next cycle
+                    newState.add(rel);
+                }
+            } else {
+                // New server file → download
+                enqueueDownload(account, rule, entry.getValue());
+                downloadCount++;
+                // Do NOT add to newState — file isn't local yet.
+                // Next sync will re-enqueue if download hasn't completed.
+            }
+        }
+
+        // 4b. Files only local
+        for (Map.Entry<String, DocumentFile> entry : localMap.entrySet()) {
+            String rel = entry.getKey();
+            boolean isRemote = remoteMap.containsKey(rel);
+            boolean wasSynced = previousState.contains(rel);
+
+            if (isRemote) {
+                // Already handled above
+                continue;
+            }
+            if (wasSynced) {
+                // Was synced before but deleted on server → remove locally
+                deleteLocalFile(localRoot, rel);
+            } else {
+                // New local file → upload
+                enqueueUpload(account, rule, rel, entry.getValue());
+                uploadCount++;
+                // Do NOT add to newState — file isn't on server yet.
+                // Next sync will re-enqueue if upload hasn't completed.
+            }
+        }
+
+        // 5. Clean up empty remote directories after file deletions
+        if (!deletedRemotePaths.isEmpty()) {
+            cleanupEmptyRemoteDirs(
+                    rule.repoId, rule.remotePath,
+                    deletedRemotePaths, newState);
+        }
+
+        // 6. Persist new sync state (merge with concurrent addSyncedFile calls)
+        SyncStateManager.setSyncedFiles(rule.id, previousState, newState);
+
+        return new int[]{downloadCount, uploadCount};
+    }
+
+    /**
+     * After deleting files, remove any remote directories that are now empty.
+     * Directories are sorted deepest-first so nested dirs are removed before parents.
+     */
+    private void cleanupEmptyRemoteDirs(
+            String repoId, String remotePath,
+            Set<String> deletedPaths, Set<String> survivingPaths) {
+        // Collect parent directories of deleted files
+        Set<String> candidateDirs = new HashSet<>();
+        for (String deleted : deletedPaths) {
+            int slash = deleted.lastIndexOf('/');
+            while (slash > 0) {
+                candidateDirs.add(deleted.substring(0, slash));
+                slash = deleted.substring(0, slash).lastIndexOf('/');
+            }
+        }
+
+        // Only delete dirs that have no surviving files underneath
+        // Sort deepest-first (longest path first) so children go before parents
+        List<String> dirsToDelete = new ArrayList<>();
+        for (String dir : candidateDirs) {
+            String prefix = dir + "/";
+            boolean hasLiveFile = false;
+            for (String alive : survivingPaths) {
+                if (alive.startsWith(prefix)) {
+                    hasLiveFile = true;
+                    break;
+                }
+            }
+            if (!hasLiveFile) {
+                dirsToDelete.add(dir);
+            }
+        }
+        // Sort longest first → deepest directories deleted first
+        dirsToDelete.sort((a, b) -> b.length() - a.length());
+
+        for (String dir : dirsToDelete) {
+            deleteRemoteDir(repoId, remotePath, dir);
+        }
+    }
+
+    /**
+     * Delete a file from the Seafile server via the REST API.
+     *
+     * @return true if deletion succeeded, false on failure (caller should retry)
+     */
+    private boolean deleteRemoteFile(
+            String repoId, String remotePath, String relativePath) {
+        String fullPath = remotePath;
+        if (!fullPath.endsWith("/")) fullPath += "/";
+        fullPath += relativePath;
+
+        try {
+            retrofit2.Response<DeleteDirentModel> resp =
+                    HttpIO.getCurrentInstance()
+                            .execute(FileService.class)
+                            .deleteFileSync(repoId, fullPath)
+                            .execute();
+            if (resp.isSuccessful()) {
+                SafeLogs.d(TAG, "Deleted remote file: " + fullPath);
+                return true;
+            } else {
+                SafeLogs.e(TAG, "Failed to delete remote file: "
+                        + fullPath + " (HTTP " + resp.code() + ")");
+                return false;
+            }
+        } catch (IOException e) {
+            SafeLogs.e(TAG, "Error deleting remote file: "
+                    + fullPath + " - " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Delete an empty directory from the Seafile server via the REST API.
+     */
+    private void deleteRemoteDir(
+            String repoId, String remotePath, String relativePath) {
+        String fullPath = remotePath;
+        if (!fullPath.endsWith("/")) fullPath += "/";
+        fullPath += relativePath;
+
+        try {
+            retrofit2.Response<DeleteDirentModel> resp =
+                    HttpIO.getCurrentInstance()
+                            .execute(FileService.class)
+                            .deleteDirSync(repoId, fullPath)
+                            .execute();
+            if (resp.isSuccessful()) {
+                SafeLogs.d(TAG, "Deleted remote dir: " + fullPath);
+            } else {
+                SafeLogs.e(TAG, "Failed to delete remote dir: "
+                        + fullPath + " (HTTP " + resp.code() + ")");
+            }
+        } catch (IOException e) {
+            SafeLogs.e(TAG, "Error deleting remote dir: "
+                    + fullPath + " - " + e.getMessage());
+        }
+    }
+
+    /**
+     * Delete a locally-synced file via SAF when it was removed on the server.
+     */
+    private void deleteLocalFile(DocumentFile localRoot, String relativePath) {
+        DocumentFile target = resolveLocalFile(localRoot, relativePath);
+        if (target != null && target.exists()) {
+            if (target.delete()) {
+                SafeLogs.d(TAG, "Deleted local file: " + relativePath);
+            } else {
+                SafeLogs.e(TAG, "Failed to delete local file: "
+                        + relativePath);
+            }
+        }
+    }
+
+    /**
+     * Resolve a relative path like "subdir/file.mp3" into a DocumentFile
+     * by traversing the SAF tree.
+     */
+    private DocumentFile resolveLocalFile(
+            DocumentFile root, String relativePath) {
+        String[] parts = relativePath.split("/");
+        DocumentFile current = root;
+        for (String part : parts) {
+            if (current == null) return null;
+            current = current.findFile(part);
+        }
+        return current;
+    }
+
+    private List<DirentRecursiveFileModel> fetchRemoteFiles(
+            String repoId, String path) throws IOException {
+        retrofit2.Response<List<DirentRecursiveFileModel>> response =
+                HttpIO.getCurrentInstance()
+                        .execute(FileService.class)
+                        .getDirRecursiveFileCall(repoId, path)
+                        .execute();
+        if (!response.isSuccessful() || response.body() == null) {
+            return Collections.emptyList();
+        }
+        return response.body();
+    }
+
+    /**
+     * Recursively scan a SAF DocumentFile tree, collecting files with their relative paths.
+     */
+    private void scanLocalFiles(DocumentFile dir, String prefix, Map<String, DocumentFile> result) {
+        if (dir == null || !dir.exists()) return;
+        DocumentFile[] children = dir.listFiles();
+        if (children == null) return;
+
+        for (DocumentFile child : children) {
+            String name = child.getName();
+            if (name == null) continue;
+
+            String relativePath = prefix.isEmpty() ? name : prefix + "/" + name;
+            if (child.isDirectory()) {
+                scanLocalFiles(child, relativePath, result);
+            } else {
+                result.put(relativePath, child);
+            }
+        }
+    }
+
+    private void enqueueDownload(Account account, SyncRule rule,
+            DirentRecursiveFileModel remoteFile) {
+        String parentDir = remoteFile.getParent_dir();
+        if (parentDir == null) parentDir = "/";
+        String fullPath = parentDir + remoteFile.name;
+
+        TransferModel tm = new TransferModel();
+        tm.save_to = SaveTo.DB;
+        tm.repo_id = rule.repoId;
+        tm.repo_name = rule.repoName;
+        tm.related_account = account.getSignature();
+        tm.file_name = remoteFile.name;
+        tm.file_size = remoteFile.size;
+        tm.full_path = fullPath;
+        tm.setParentPath(Utils.getParentPath(fullPath));
+        tm.target_path = DataManager.getLocalFileCachePath(
+                account, rule.repoId, rule.repoName, fullPath)
+                .getAbsolutePath();
+        tm.transfer_status = TransferStatus.WAITING;
+        tm.data_source = FeatureDataSource.DOWNLOAD;
+        tm.created_at = System.nanoTime();
+        tm.transfer_strategy = ExistingFileStrategy.REPLACE;
+        tm.setId(tm.genStableId());
+
+        GlobalTransferCacheList.DOWNLOAD_QUEUE.put(tm);
+    }
+
+    private void enqueueUpload(Account account, SyncRule rule,
+            String relativePath, DocumentFile localFile) {
+        // Compute remote target path
+        String remotePath = rule.remotePath;
+        if (!remotePath.endsWith("/")) remotePath += "/";
+        String targetPath = remotePath + relativePath;
+
+        TransferModel tm = new TransferModel();
+        tm.save_to = SaveTo.DB;
+        tm.repo_id = rule.repoId;
+        tm.repo_name = rule.repoName;
+        tm.related_account = account.getSignature();
+        tm.file_name = localFile.getName();
+        tm.file_size = localFile.length();
+        // content:// URI — handled by ProgressUriRequestBody
+        tm.full_path = localFile.getUri().toString();
+        tm.target_path = targetPath;
+        tm.setParentPath(Utils.getParentPath(targetPath));
+        tm.transfer_status = TransferStatus.WAITING;
+        tm.data_source = FeatureDataSource.FOLDER_SYNC;
+        tm.created_at = System.nanoTime();
+        tm.transfer_strategy = ExistingFileStrategy.APPEND;
+        tm.setId(tm.genStableId());
+
+        GlobalTransferCacheList.FOLDER_SYNC_QUEUE.put(tm);
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/framework/worker/GlobalTransferCacheList.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/worker/GlobalTransferCacheList.java
@@ -15,9 +15,10 @@ public class GlobalTransferCacheList {
      * Put local updated files into queue
      */
     public static final TransferQueue LOCAL_FILE_MONITOR_QUEUE = new TransferQueue();
+    public static final TransferQueue FOLDER_SYNC_QUEUE = new TransferQueue();
 
     public static int getUploadPendingCount() {
-        return FOLDER_BACKUP_QUEUE.getPendingCount() + ALBUM_BACKUP_QUEUE.getPendingCount() + FILE_UPLOAD_QUEUE.getPendingCount();
+        return FOLDER_BACKUP_QUEUE.getPendingCount() + ALBUM_BACKUP_QUEUE.getPendingCount() + FILE_UPLOAD_QUEUE.getPendingCount() + FOLDER_SYNC_QUEUE.getPendingCount();
     }
 
     public static int getDownloadPendingCount() {
@@ -30,6 +31,7 @@ public class GlobalTransferCacheList {
         FILE_UPLOAD_QUEUE.clear();
         DOWNLOAD_QUEUE.clear();
         SHARE_FILE_TO_SEAFILE_QUEUE.clear();
+        FOLDER_SYNC_QUEUE.clear();
     }
 
     public static void updateTransferModel(TransferModel transferModel) {
@@ -47,6 +49,8 @@ public class GlobalTransferCacheList {
             DOWNLOAD_QUEUE.update(transferModel);
         } else if (transferModel.data_source == FeatureDataSource.SHARE_FILE_TO_SEAFILE) {
             SHARE_FILE_TO_SEAFILE_QUEUE.update(transferModel);
+        } else if (transferModel.data_source == FeatureDataSource.FOLDER_SYNC) {
+            FOLDER_SYNC_QUEUE.update(transferModel);
         }
     }
 }

--- a/app/src/main/java/com/seafile/seadroid2/framework/worker/download/DownloadWorker.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/worker/download/DownloadWorker.java
@@ -1,11 +1,13 @@
 package com.seafile.seadroid2.framework.worker.download;
 
 import android.content.Context;
+import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Pair;
 
 import androidx.annotation.NonNull;
+import androidx.documentfile.provider.DocumentFile;
 import androidx.work.ForegroundInfo;
 import androidx.work.WorkerParameters;
 
@@ -22,6 +24,8 @@ import com.seafile.seadroid2.enums.TransferResult;
 import com.seafile.seadroid2.enums.TransferStatus;
 import com.seafile.seadroid2.framework.crypto.SecurePasswordManager;
 import com.seafile.seadroid2.framework.datastore.DataManager;
+import com.seafile.seadroid2.framework.datastore.SyncRule;
+import com.seafile.seadroid2.framework.datastore.SyncRuleManager;
 import com.seafile.seadroid2.framework.datastore.sp.SettingsManager;
 import com.seafile.seadroid2.framework.db.AppDatabase;
 import com.seafile.seadroid2.framework.db.entities.EncKeyCacheEntity;
@@ -44,11 +48,15 @@ import com.seafile.seadroid2.ui.file.FileService;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URLEncoder;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -357,13 +365,101 @@ public class DownloadWorker extends BaseDownloadWorker {
                 }
 
                 //important
-                Path path = java.nio.file.Files.move(tempFile.toPath(), localFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-                boolean isSuccess = path.toFile().exists();
-                if (isSuccess) {
-                    java.nio.file.Files.deleteIfExists(tempFile.toPath());
-                    updateToSuccess(fileId, localFile);
+                // Check if this file matches a sync rule
+                SyncRule syncRule = SyncRuleManager.findMatch(currentTransferModel.repo_id, currentTransferModel.full_path);
+
+                if (syncRule != null) {
+                    // Move file to the user's chosen sync destination (not a copy)
+                    boolean moved = moveToSyncDestination(tempFile, syncRule, currentTransferModel.full_path);
+                    if (moved) {
+                        Files.deleteIfExists(tempFile.toPath());
+                        updateToSuccess(fileId, localFile);
+                    } else {
+                        // Fallback to normal cache if sync dest fails
+                        SLogs.d(TAG, "download()", "Sync dest failed, falling back to cache");
+                        Path path = Files.move(tempFile.toPath(), localFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                        if (path.toFile().exists()) {
+                            Files.deleteIfExists(tempFile.toPath());
+                            updateToSuccess(fileId, localFile);
+                        }
+                    }
+                } else {
+                    // No sync rule — normal cache behavior
+                    Path path = Files.move(tempFile.toPath(), localFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                    boolean isSuccess = path.toFile().exists();
+                    if (isSuccess) {
+                        Files.deleteIfExists(tempFile.toPath());
+                        updateToSuccess(fileId, localFile);
+                    }
                 }
             }
+        }
+    }
+
+    /**
+     * Moves a temp file to the sync destination folder using SAF.
+     * Creates subdirectories as needed to preserve the relative path structure.
+     * Returns true on success.
+     */
+    private boolean moveToSyncDestination(File tempFile, SyncRule rule, String fullPath) {
+        try {
+            Uri treeUri = Uri.parse(rule.localUri);
+            DocumentFile destDir = DocumentFile.fromTreeUri(getApplicationContext(), treeUri);
+            if (destDir == null || !destDir.exists() || !destDir.canWrite()) {
+                SLogs.d(TAG, "moveToSyncDestination()", "Sync destination not accessible");
+                return false;
+            }
+
+            // Create subdirectories for the relative path
+            String relativePath = rule.getRelativePath(fullPath);
+            String[] parts = relativePath.split("/");
+            String fileName = parts[parts.length - 1];
+
+            // Navigate/create intermediate directories
+            DocumentFile currentDir = destDir;
+            for (int i = 0; i < parts.length - 1; i++) {
+                String dirName = parts[i];
+                if (dirName.isEmpty()) continue;
+                DocumentFile subDir = currentDir.findFile(dirName);
+                if (subDir == null || !subDir.isDirectory()) {
+                    subDir = currentDir.createDirectory(dirName);
+                }
+                if (subDir == null) {
+                    SLogs.d(TAG, "moveToSyncDestination()", "Failed to create subdirectory: " + dirName);
+                    return false;
+                }
+                currentDir = subDir;
+            }
+
+            // Remove existing file with same name
+            DocumentFile existingFile = currentDir.findFile(fileName);
+            if (existingFile != null) {
+                existingFile.delete();
+            }
+
+            DocumentFile newFile = currentDir.createFile("application/octet-stream", fileName);
+            if (newFile == null) {
+                SLogs.d(TAG, "moveToSyncDestination()", "Failed to create file");
+                return false;
+            }
+
+            try (InputStream in = new FileInputStream(tempFile);
+                 OutputStream out = getApplicationContext().getContentResolver().openOutputStream(newFile.getUri())) {
+                if (out == null) {
+                    return false;
+                }
+                byte[] buffer = new byte[SEGMENT_SIZE];
+                int bytesRead;
+                while ((bytesRead = in.read(buffer)) != -1) {
+                    out.write(buffer, 0, bytesRead);
+                }
+            }
+
+            SLogs.d(TAG, "moveToSyncDestination()", "Moved to sync dest: " + fileName);
+            return true;
+        } catch (IOException e) {
+            SLogs.e(TAG, "moveToSyncDestination()", "Failed: " + e.getMessage());
+            return false;
         }
     }
 

--- a/app/src/main/java/com/seafile/seadroid2/framework/worker/queue/TransferQueue.java
+++ b/app/src/main/java/com/seafile/seadroid2/framework/worker/queue/TransferQueue.java
@@ -337,6 +337,27 @@ public class TransferQueue {
         }
     }
 
+    /**
+     * Remove all entries whose TransferModel matches the predicate.
+     */
+    public synchronized void removeIf(java.util.function.Predicate<TransferModel> predicate) {
+        List<String> toRemove = new ArrayList<>();
+        for (TransferModel model : getTransferMap().values()) {
+            if (predicate.test(model)) {
+                toRemove.add(model.getId());
+            }
+        }
+        for (String id : toRemove) {
+            getTransferMap().remove(id);
+        }
+        if (!toRemove.isEmpty() && !getTransferQueue().isEmpty()) {
+            List<String> remaining = getTransferQueue().stream()
+                    .filter(id -> !toRemove.contains(id))
+                    .collect(Collectors.toList());
+            addAllIntoQueueClearOld(remaining);
+        }
+    }
+
     public void clear() {
         getCategoryMap().clear();
         getTransferMap().clear();

--- a/app/src/main/java/com/seafile/seadroid2/ui/file/FileService.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/file/FileService.java
@@ -1,5 +1,6 @@
 package com.seafile.seadroid2.ui.file;
 
+import com.seafile.seadroid2.framework.model.dirents.DeleteDirentModel;
 import com.seafile.seadroid2.framework.model.dirents.DirentDirModel;
 import com.seafile.seadroid2.framework.model.dirents.DirentFileModel;
 import com.seafile.seadroid2.framework.model.dirents.DirentRecursiveFileModel;
@@ -10,6 +11,7 @@ import java.util.Map;
 import io.reactivex.Single;
 import okhttp3.RequestBody;
 import retrofit2.Call;
+import retrofit2.http.DELETE;
 import retrofit2.http.GET;
 import retrofit2.http.Multipart;
 import retrofit2.http.POST;
@@ -60,4 +62,14 @@ public interface FileService {
 
     @GET("api2/repos/{repo_id}/update-link/")
     Single<String> getFileUpdateLinkSync(@Path("repo_id") String repoId);
+
+    @DELETE("api/v2.1/repos/{repo_id}/file/")
+    Call<DeleteDirentModel> deleteFileSync(
+            @Path("repo_id") String repoId,
+            @Query("p") String path);
+
+    @DELETE("api/v2.1/repos/{repo_id}/dir/")
+    Call<DeleteDirentModel> deleteDirSync(
+            @Path("repo_id") String repoId,
+            @Query("p") String path);
 }

--- a/app/src/main/java/com/seafile/seadroid2/ui/folder_sync/FolderSyncFilesActivity.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/folder_sync/FolderSyncFilesActivity.java
@@ -1,0 +1,151 @@
+package com.seafile.seadroid2.ui.folder_sync;
+
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import android.widget.TextView;
+
+import com.seafile.seadroid2.R;
+import com.seafile.seadroid2.framework.datastore.SyncExclusionManager;
+import com.seafile.seadroid2.framework.datastore.SyncRule;
+import com.seafile.seadroid2.framework.datastore.SyncRuleManager;
+import com.seafile.seadroid2.framework.http.HttpIO;
+import com.seafile.seadroid2.framework.model.dirents.DirentRecursiveFileModel;
+import com.seafile.seadroid2.framework.worker.BackgroundJobManagerImpl;
+import com.seafile.seadroid2.ui.base.BaseActivity;
+import com.seafile.seadroid2.ui.file.FileService;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executors;
+
+/**
+ * Shows all remote files for a sync rule with checkboxes.
+ * Checked = included in sync (will be downloaded).
+ * Unchecked = excluded (will be deleted locally if present).
+ * New server files are auto-checked.
+ */
+public class FolderSyncFilesActivity extends BaseActivity {
+    public static final String EXTRA_RULE_ID = "rule_id";
+
+    private RecyclerView recyclerView;
+    private TextView tvLoading;
+    private TextView tvEmpty;
+    private SyncRule rule;
+    private SyncFileAdapter adapter;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_folder_sync_files);
+
+        Toolbar toolbar = getActionBarToolbar();
+        if (toolbar != null) {
+            toolbar.setNavigationOnClickListener(v -> finish());
+        }
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setTitle(R.string.settings_folder_sync_files_title);
+        }
+
+        recyclerView = findViewById(R.id.rv_files);
+        tvLoading = findViewById(R.id.tv_loading);
+        tvEmpty = findViewById(R.id.tv_empty);
+
+        String ruleId = getIntent().getStringExtra(EXTRA_RULE_ID);
+        if (ruleId == null) {
+            finish();
+            return;
+        }
+
+        rule = SyncRuleManager.findById(ruleId);
+        if (rule == null) {
+            finish();
+            return;
+        }
+
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new SyncFileAdapter(rule);
+        recyclerView.setAdapter(adapter);
+
+        // Apply system bar insets so the list doesn't go behind the nav bar
+        androidx.core.view.ViewCompat.setOnApplyWindowInsetsListener(recyclerView, (v, insets) -> {
+            androidx.core.graphics.Insets nav = insets.getInsets(
+                    androidx.core.view.WindowInsetsCompat.Type.systemBars());
+            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(),
+                    v.getPaddingRight(), nav.bottom);
+            return insets;
+        });
+
+        loadRemoteFiles();
+    }
+
+    private void loadRemoteFiles() {
+        tvLoading.setVisibility(View.VISIBLE);
+        recyclerView.setVisibility(View.GONE);
+        tvEmpty.setVisibility(View.GONE);
+
+        Executors.newSingleThreadExecutor().execute(() -> {
+            try {
+                retrofit2.Response<List<DirentRecursiveFileModel>> response =
+                        HttpIO.getCurrentInstance()
+                                .execute(FileService.class)
+                                .getDirRecursiveFileCall(rule.repoId, rule.remotePath)
+                                .execute();
+
+                List<SyncFileItem> items = new ArrayList<>();
+                if (response.isSuccessful() && response.body() != null) {
+                    Set<String> exclusions = SyncExclusionManager.getExcludedFiles(rule.id);
+                    for (DirentRecursiveFileModel rf : response.body()) {
+                        String fullPath = rf.getParent_dir() + rf.name;
+                        String relativePath = rule.getRelativePath(fullPath);
+                        boolean included = !exclusions.contains(relativePath);
+                        items.add(new SyncFileItem(relativePath, rf.name, rf.size, included));
+                    }
+                }
+
+                // Sort by path
+                items.sort((a, b) -> a.relativePath.compareToIgnoreCase(b.relativePath));
+
+                runOnUiThread(() -> {
+                    tvLoading.setVisibility(View.GONE);
+                    if (items.isEmpty()) {
+                        tvEmpty.setVisibility(View.VISIBLE);
+                    } else {
+                        recyclerView.setVisibility(View.VISIBLE);
+                        adapter.setItems(items);
+                    }
+                });
+            } catch (Exception e) {
+                runOnUiThread(() -> {
+                    tvLoading.setVisibility(View.GONE);
+                    tvEmpty.setVisibility(View.VISIBLE);
+                    tvEmpty.setText(e.getMessage());
+                });
+            }
+        });
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        // Trigger a sync to apply exclusion changes (delete excluded files, etc.)
+        BackgroundJobManagerImpl.getInstance().runFolderSyncNow();
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/ui/folder_sync/SyncFileAdapter.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/folder_sync/SyncFileAdapter.java
@@ -1,0 +1,118 @@
+package com.seafile.seadroid2.ui.folder_sync;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.blankj.utilcode.util.EncryptUtils;
+import com.seafile.seadroid2.R;
+import com.seafile.seadroid2.enums.FeatureDataSource;
+import com.seafile.seadroid2.framework.datastore.SyncExclusionManager;
+import com.seafile.seadroid2.framework.datastore.SyncRule;
+import com.seafile.seadroid2.framework.service.BackupThreadExecutor;
+import com.seafile.seadroid2.framework.util.Utils;
+import com.seafile.seadroid2.framework.worker.GlobalTransferCacheList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * RecyclerView adapter for the per-file toggle list.
+ * Checking/unchecking immediately persists the exclusion state
+ * and purges/stops matching downloads from the queue.
+ */
+public class SyncFileAdapter extends RecyclerView.Adapter<SyncFileAdapter.ViewHolder> {
+
+    private final SyncRule rule;
+    private final List<SyncFileItem> items = new ArrayList<>();
+
+    public SyncFileAdapter(SyncRule rule) {
+        this.rule = rule;
+    }
+
+    public void setItems(List<SyncFileItem> newItems) {
+        items.clear();
+        items.addAll(newItems);
+        notifyDataSetChanged();
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item_sync_file, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        SyncFileItem item = items.get(position);
+
+        holder.tvFileName.setText(item.relativePath);
+        holder.tvFileSize.setText(Utils.readableFileSize(item.fileSize));
+
+        // Avoid triggering listener during bind
+        holder.cbFile.setOnCheckedChangeListener(null);
+        holder.cbFile.setChecked(item.included);
+
+        holder.cbFile.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            item.included = isChecked;
+            if (isChecked) {
+                SyncExclusionManager.includeFile(rule.id, item.relativePath);
+            } else {
+                SyncExclusionManager.excludeFile(rule.id, item.relativePath);
+                // Immediately remove from download queue if queued/in-progress
+                removeFromDownloadQueue(item.relativePath);
+            }
+        });
+
+        // Make entire row clickable to toggle
+        holder.itemView.setOnClickListener(v -> {
+            holder.cbFile.setChecked(!holder.cbFile.isChecked());
+        });
+    }
+
+    /**
+     * Remove any queued or actively downloading transfer for this file.
+     */
+    private void removeFromDownloadQueue(String relativePath) {
+        // Remove from the pending queue
+        GlobalTransferCacheList.DOWNLOAD_QUEUE.removeIf(tm ->
+                rule.repoId.equals(tm.repo_id)
+                && tm.full_path != null
+                && relativePath.equals(rule.getRelativePath(tm.full_path))
+        );
+
+        // Cancel the active download if it matches this file
+        String remotePath = rule.remotePath;
+        if (!remotePath.endsWith("/")) remotePath += "/";
+        String fullPath = remotePath + relativePath;
+        String modelId = EncryptUtils.encryptMD5ToString(
+                FeatureDataSource.DOWNLOAD.toString() + rule.repoId + fullPath);
+        BackupThreadExecutor.getInstance()
+                .stopSpecialTransmitter(modelId, FeatureDataSource.DOWNLOAD);
+    }
+
+    @Override
+    public int getItemCount() {
+        return items.size();
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+        final CheckBox cbFile;
+        final TextView tvFileName;
+        final TextView tvFileSize;
+
+        ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            cbFile = itemView.findViewById(R.id.cb_file);
+            tvFileName = itemView.findViewById(R.id.tv_file_name);
+            tvFileSize = itemView.findViewById(R.id.tv_file_size);
+        }
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/ui/folder_sync/SyncFileItem.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/folder_sync/SyncFileItem.java
@@ -1,0 +1,18 @@
+package com.seafile.seadroid2.ui.folder_sync;
+
+/**
+ * Represents a single remote file in the per-file toggle list.
+ */
+public class SyncFileItem {
+    public final String relativePath;
+    public final String fileName;
+    public final long fileSize;
+    public boolean included;
+
+    public SyncFileItem(String relativePath, String fileName, long fileSize, boolean included) {
+        this.relativePath = relativePath;
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+        this.included = included;
+    }
+}

--- a/app/src/main/java/com/seafile/seadroid2/ui/main/MainActivity.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/main/MainActivity.java
@@ -43,6 +43,8 @@ import com.seafile.seadroid2.context.GlobalNavContext;
 import com.seafile.seadroid2.context.NavContext;
 import com.seafile.seadroid2.databinding.ActivityMainBinding;
 import com.seafile.seadroid2.enums.NightMode;
+import com.seafile.seadroid2.framework.datastore.SyncRuleManager;
+import com.seafile.seadroid2.framework.worker.BackgroundJobManagerImpl;
 import com.seafile.seadroid2.framework.file_monitor.FileDaemonServiceManager;
 import com.seafile.seadroid2.framework.file_monitor.FileSyncService;
 import com.seafile.seadroid2.framework.model.ServerInfo;
@@ -225,6 +227,11 @@ public class MainActivity extends BaseActivity {
 //        BackgroundJobManagerImpl.getInstance().getWorkManager().enqueue(oneTimeWorkRequest);
 
         requestNotificationPermission();
+
+        // Start periodic folder sync if rules exist
+        if (!SyncRuleManager.getAll().isEmpty()) {
+            BackgroundJobManagerImpl.getInstance().scheduleFolderSync();
+        }
     }
 
     private void requestNotificationPermission() {

--- a/app/src/main/java/com/seafile/seadroid2/ui/settings/TabSettings2Fragment.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/settings/TabSettings2Fragment.java
@@ -32,6 +32,7 @@ import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.preference.ListPreference;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
 
 import com.blankj.utilcode.util.AppUtils;
 import com.blankj.utilcode.util.CollectionUtils;
@@ -53,6 +54,8 @@ import com.seafile.seadroid2.enums.FeatureDataSource;
 import com.seafile.seadroid2.enums.NetworkMode;
 import com.seafile.seadroid2.enums.ObjSelectType;
 import com.seafile.seadroid2.framework.datastore.StorageManager;
+import com.seafile.seadroid2.framework.datastore.SyncRule;
+import com.seafile.seadroid2.framework.datastore.SyncRuleManager;
 import com.seafile.seadroid2.framework.datastore.sp_livedata.AlbumBackupSharePreferenceHelper;
 import com.seafile.seadroid2.framework.datastore.sp_livedata.FolderBackupSharePreferenceHelper;
 import com.seafile.seadroid2.framework.file_monitor.FileDaemonServiceManager;
@@ -137,6 +140,10 @@ public class TabSettings2Fragment extends RenameSharePreferenceFragmentCompat {
 
     private TextSwitchPreference mBiometricLockSwitch;
     private SimpleMenuPreference mLockTimeoutPref;
+
+    // Folder sync
+    private PreferenceCategory mFolderSyncCategory;
+    private SyncRule mPendingSyncRule;  // temp rule being built during 2-step add flow
 
     public static TabSettings2Fragment newInstance() {
         return new TabSettings2Fragment();
@@ -284,6 +291,8 @@ public class TabSettings2Fragment extends RenameSharePreferenceFragmentCompat {
         initFolderBackupPref();
 
         initTransferPref();
+
+        initFolderSyncPref();
 
         initCachePref();
 
@@ -477,6 +486,178 @@ public class TabSettings2Fragment extends RenameSharePreferenceFragmentCompat {
                 return true;
             });
         }
+    }
+
+    private void initFolderSyncPref() {
+        mFolderSyncCategory = findPreference(getString(R.string.pref_key_folder_sync_category));
+
+        Preference addPref = findPreference(getString(R.string.pref_key_folder_sync_add));
+        if (addPref != null) {
+            addPref.setOnPreferenceClickListener(preference -> {
+                // Step 1: pick Seafile repo + dir
+                Intent intent = ObjSelectorActivity.getCurrentAccountIntent(
+                        requireContext(),
+                        ObjSelectType.REPO,
+                        ObjSelectType.DIR,
+                        null
+                );
+                syncRuleRemotePickerLauncher.launch(intent);
+                return true;
+            });
+        }
+
+        refreshSyncRulePrefs();
+
+        Preference syncNowPref = findPreference(getString(R.string.pref_key_folder_sync_now));
+        if (syncNowPref != null) {
+            syncNowPref.setOnPreferenceClickListener(preference -> {
+                BackgroundJobManagerImpl.getInstance().runFolderSyncNow();
+                Toasts.show(R.string.settings_folder_sync_started);
+                return true;
+            });
+        }
+    }
+
+    private void refreshSyncRulePrefs() {
+        if (mFolderSyncCategory == null) {
+            return;
+        }
+
+        // Remove all dynamically-added rule preferences (keep the "Add" and "Sync now" buttons)
+        String addKey = getString(R.string.pref_key_folder_sync_add);
+        String syncNowKey = getString(R.string.pref_key_folder_sync_now);
+        List<Preference> toRemove = new ArrayList<>();
+        for (int i = 0; i < mFolderSyncCategory.getPreferenceCount(); i++) {
+            Preference p = mFolderSyncCategory.getPreference(i);
+            if (!addKey.equals(p.getKey()) && !syncNowKey.equals(p.getKey())) {
+                toRemove.add(p);
+            }
+        }
+        for (Preference p : toRemove) {
+            mFolderSyncCategory.removePreference(p);
+        }
+
+        // Add a preference for each sync rule
+        List<SyncRule> rules = SyncRuleManager.getAll();
+        Preference addPref = findPreference(addKey);
+
+        for (SyncRule rule : rules) {
+            TextTitleSummaryPreference rulePref = new TextTitleSummaryPreference(requireContext());
+            rulePref.setKey("sync_rule_" + rule.id);
+            rulePref.setTitle(rule.getDisplaySummary());
+            rulePref.setSummary(rule.enabled
+                    ? getString(R.string.settings_folder_sync_enabled)
+                    : getString(R.string.settings_folder_sync_disabled));
+            rulePref.setIconSpaceReserved(false);
+
+            rulePref.setOnPreferenceClickListener(preference -> {
+                showSyncRuleOptions(rule);
+                return true;
+            });
+
+            // Insert before the "Add" button
+            if (addPref != null) {
+                rulePref.setOrder(addPref.getOrder() - 1);
+            }
+            mFolderSyncCategory.addPreference(rulePref);
+        }
+    }
+
+    private void showSyncRuleOptions(SyncRule rule) {
+        String toggleLabel = rule.enabled
+                ? getString(R.string.settings_folder_sync_disabled)
+                : getString(R.string.settings_folder_sync_enabled);
+
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(rule.getDisplaySummary())
+                .setItems(new CharSequence[]{
+                        toggleLabel,
+                        getString(R.string.settings_folder_sync_manage_files),
+                        getString(R.string.settings_folder_sync_filters),
+                        getString(R.string.delete)
+                }, (dialog, which) -> {
+                    if (which == 0) {
+                        rule.enabled = !rule.enabled;
+                        SyncRuleManager.update(rule);
+                        refreshSyncRulePrefs();
+                    } else if (which == 1) {
+                        // Open per-file toggle activity
+                        Intent intent = new Intent(requireContext(),
+                                com.seafile.seadroid2.ui.folder_sync.FolderSyncFilesActivity.class);
+                        intent.putExtra(
+                                com.seafile.seadroid2.ui.folder_sync.FolderSyncFilesActivity.EXTRA_RULE_ID,
+                                rule.id);
+                        startActivity(intent);
+                    } else if (which == 2) {
+                        showFilterDialog(rule);
+                    } else {
+                        new MaterialAlertDialogBuilder(requireContext())
+                                .setMessage(R.string.settings_folder_sync_delete_confirm)
+                                .setPositiveButton(R.string.delete, (d2, w2) -> {
+                                    SyncRuleManager.remove(rule.id);
+                                    refreshSyncRulePrefs();
+                                    Toasts.show(R.string.settings_folder_sync_removed);
+                                    // Stop periodic sync if no rules left
+                                    if (SyncRuleManager.getAll().isEmpty()) {
+                                        BackgroundJobManagerImpl.getInstance().stopFolderSync();
+                                    }
+                                })
+                                .setNegativeButton(R.string.cancel, null)
+                                .show();
+                    }
+                })
+                .show();
+    }
+
+    private void showFilterDialog(SyncRule rule) {
+        View dialogView = getLayoutInflater().inflate(
+                R.layout.dialog_sync_filters, null);
+        android.widget.EditText etMaxSize = dialogView.findViewById(R.id.et_max_size);
+        android.widget.EditText etExtensions = dialogView.findViewById(R.id.et_extensions);
+        android.widget.RadioGroup rgMode = dialogView.findViewById(R.id.rg_filter_mode);
+
+        // Populate current values
+        if (rule.maxFileSize > 0) {
+            etMaxSize.setText(String.valueOf(rule.maxFileSize / (1024 * 1024)));
+        }
+        if (rule.extensionFilter != null) {
+            etExtensions.setText(rule.extensionFilter);
+        }
+        if ("exclude".equals(rule.filterMode)) {
+            rgMode.check(R.id.rb_exclude);
+        } else {
+            rgMode.check(R.id.rb_include);
+        }
+
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.settings_folder_sync_filters)
+                .setView(dialogView)
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                    // Parse max size
+                    String sizeStr = etMaxSize.getText().toString().trim();
+                    if (sizeStr.isEmpty() || "0".equals(sizeStr)) {
+                        rule.maxFileSize = 0;
+                    } else {
+                        try {
+                            rule.maxFileSize = Long.parseLong(sizeStr) * 1024 * 1024;
+                        } catch (NumberFormatException e) {
+                            rule.maxFileSize = 0;
+                        }
+                    }
+
+                    // Parse extensions
+                    rule.extensionFilter = etExtensions.getText().toString()
+                            .trim().toLowerCase(java.util.Locale.US);
+
+                    // Parse mode
+                    rule.filterMode = rgMode.getCheckedRadioButtonId() == R.id.rb_exclude
+                            ? "exclude" : "include";
+
+                    SyncRuleManager.update(rule);
+                    Toasts.show(R.string.settings_folder_sync_filters_saved);
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
     }
 
     private SwitchStorageDialogFragment dialogFragment;
@@ -1284,8 +1465,80 @@ public class TabSettings2Fragment extends RenameSharePreferenceFragmentCompat {
     private ActivityResultLauncher<Intent> folderBackupConfigLauncher;
     private ActivityResultLauncher<String[]> readWritePermissionLauncher;
     private ActivityResultLauncher<Intent> manageAllFilesPermissionLauncher;
+    private ActivityResultLauncher<Intent> syncRuleRemotePickerLauncher;
+    private ActivityResultLauncher<Uri> syncRuleLocalPickerLauncher;
 
     private void registerResultLauncher() {
+        syncRuleRemotePickerLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), new ActivityResultCallback<ActivityResult>() {
+            @Override
+            public void onActivityResult(ActivityResult o) {
+                if (o == null || o.getResultCode() != RESULT_OK || o.getData() == null) {
+                    return;
+                }
+
+                Intent data = o.getData();
+                String repoId = data.getStringExtra(ObjKey.REPO_ID);
+                String repoName = data.getStringExtra(ObjKey.REPO_NAME);
+                String dir = data.getStringExtra(ObjKey.DIR);
+                if (TextUtils.isEmpty(repoId)) {
+                    return;
+                }
+                if (TextUtils.isEmpty(dir)) {
+                    dir = "/";
+                }
+
+                // Save partial rule and proceed to step 2: pick local folder
+                mPendingSyncRule = new SyncRule();
+                mPendingSyncRule.repoId = repoId;
+                mPendingSyncRule.repoName = repoName;
+                mPendingSyncRule.remotePath = dir;
+
+                syncRuleLocalPickerLauncher.launch(null);
+            }
+        });
+
+        syncRuleLocalPickerLauncher = registerForActivityResult(new ActivityResultContracts.OpenDocumentTree(), new ActivityResultCallback<Uri>() {
+            @Override
+            public void onActivityResult(Uri uri) {
+                if (uri == null || mPendingSyncRule == null) {
+                    mPendingSyncRule = null;
+                    return;
+                }
+
+                // Take persistable permission
+                try {
+                    requireContext().getContentResolver()
+                            .takePersistableUriPermission(uri,
+                                    Intent.FLAG_GRANT_READ_URI_PERMISSION
+                                            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                } catch (SecurityException e) {
+                    Toasts.show(R.string.permission_not_granted);
+                    mPendingSyncRule = null;
+                    return;
+                }
+
+                mPendingSyncRule.localUri = uri.toString();
+
+                // Derive a display name from the URI
+                String segment = uri.getLastPathSegment();
+                if (segment != null) {
+                    mPendingSyncRule.localName = segment.replace(":", "/");
+                } else {
+                    mPendingSyncRule.localName = uri.toString();
+                }
+
+                SyncRuleManager.add(mPendingSyncRule);
+                mPendingSyncRule = null;
+
+                refreshSyncRulePrefs();
+                Toasts.show(R.string.settings_folder_sync_added);
+
+                // Ensure periodic sync is scheduled, then trigger immediate sync
+                BackgroundJobManagerImpl.getInstance().scheduleFolderSync();
+                BackgroundJobManagerImpl.getInstance().runFolderSyncNow();
+            }
+        });
+
         folderSelectorLauncher = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), new ActivityResultCallback<ActivityResult>() {
             @Override
             public void onActivityResult(ActivityResult o) {

--- a/app/src/main/res/layout/activity_folder_sync_files.xml
+++ b/app/src/main/res/layout/activity_folder_sync_files.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include layout="@layout/toolbar_actionbar" />
+
+    <TextView
+        android:id="@+id/tv_loading"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="@string/settings_folder_sync_files_loading"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/tv_empty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="@string/settings_folder_sync_files_empty"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_files"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:fitsSystemWindows="true" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_sync_filters.xml
+++ b/app/src/main/res/layout/dialog_sync_filters.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/settings_folder_sync_max_size"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <EditText
+        android:id="@+id/et_max_size"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/settings_folder_sync_max_size_hint"
+        android:inputType="number"
+        android:importantForAutofill="no" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/settings_folder_sync_ext_filter"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <EditText
+        android:id="@+id/et_extensions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/settings_folder_sync_ext_filter_hint"
+        android:inputType="text"
+        android:importantForAutofill="no" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/settings_folder_sync_filter_mode"
+        android:textSize="14sp"
+        android:textStyle="bold" />
+
+    <RadioGroup
+        android:id="@+id/rg_filter_mode"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp">
+
+        <RadioButton
+            android:id="@+id/rb_include"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_folder_sync_filter_include" />
+
+        <RadioButton
+            android:id="@+id/rb_exclude"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/settings_folder_sync_filter_exclude" />
+
+    </RadioGroup>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_sync_file.xml
+++ b/app/src/main/res/layout/item_sync_file.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="12dp"
+    android:paddingBottom="12dp">
+
+    <CheckBox
+        android:id="@+id/cb_file"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:paddingStart="8dp">
+
+        <TextView
+            android:id="@+id/tv_file_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="middle"
+            android:singleLine="true"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/tv_file_size"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textColor="?android:textColorSecondary" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/donottranslate_prefs.xml
+++ b/app/src/main/res/values/donottranslate_prefs.xml
@@ -104,6 +104,11 @@
     </string-array>
 
 
+    <!-- folder sync -->
+    <string name="pref_key_folder_sync_category">key_folder_sync_category</string>
+    <string name="pref_key_folder_sync_add">key_folder_sync_add</string>
+    <string name="pref_key_folder_sync_now">key_folder_sync_now</string>
+
     <!-- cache -->
     <string name="pref_key_cache_info">key_cache_info</string>
     <string name="pref_key_cache_location">key_cache_location</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -475,6 +475,35 @@
     </string>
     <string name="settings_advance_feature_title">ADVANCED FEATURES</string>
     <string name="settings_transfer_title">UPLOAD &amp; DOWNLOAD</string>
+    <string name="settings_folder_sync_title">FOLDER SYNC</string>
+    <string name="settings_folder_sync_add">Add sync rule</string>
+    <string name="settings_folder_sync_add_summary">Map a Seafile folder to a local folder</string>
+    <string name="settings_folder_sync_empty">No sync rules configured</string>
+    <string name="settings_folder_sync_pick_remote">Select Seafile folder</string>
+    <string name="settings_folder_sync_pick_local">Select local folder</string>
+    <string name="settings_folder_sync_added">Sync rule added</string>
+    <string name="settings_folder_sync_removed">Sync rule removed</string>
+    <string name="settings_folder_sync_delete_confirm">Remove this sync rule?</string>
+    <string name="settings_folder_sync_enabled">Enabled</string>
+    <string name="settings_folder_sync_disabled">Disabled</string>
+    <string name="settings_folder_sync_now">Sync now</string>
+    <string name="settings_folder_sync_now_summary">Manually trigger folder sync</string>
+    <string name="settings_folder_sync_started">Folder sync started</string>
+    <string name="settings_folder_sync_syncing">Syncing files…</string>
+    <string name="settings_folder_sync_manage_files">Manage files</string>
+    <string name="settings_folder_sync_filters">Filters</string>
+    <string name="settings_folder_sync_max_size">Max file size (MB)</string>
+    <string name="settings_folder_sync_max_size_hint">0 = unlimited</string>
+    <string name="settings_folder_sync_ext_filter">File extensions</string>
+    <string name="settings_folder_sync_ext_filter_hint">e.g. mp3,flac,wav (empty = all)</string>
+    <string name="settings_folder_sync_filter_mode">Filter mode</string>
+    <string name="settings_folder_sync_filter_include">Include only these extensions</string>
+    <string name="settings_folder_sync_filter_exclude">Exclude these extensions</string>
+    <string name="settings_folder_sync_filters_saved">Filters saved</string>
+    <string name="settings_folder_sync_files_title">Manage synced files</string>
+    <string name="settings_folder_sync_files_loading">Loading file list…</string>
+    <string name="settings_folder_sync_files_empty">No files found on server</string>
+    <string name="settings_folder_sync_files_excluded">%1$d excluded</string>
     <string name="settings_storage_title">CACHE STORAGE</string>
     <string name="settings_cache_title">Cache size</string>
     <string name="settings_clear_cache_title">Clear cache</string>

--- a/app/src/main/res/xml/prefs_settings_2.xml
+++ b/app/src/main/res/xml/prefs_settings_2.xml
@@ -291,6 +291,31 @@
     </com.seafile.seadroid2.widget.prefs.CardPreferenceCategory>
 
     <com.seafile.seadroid2.widget.prefs.CardPreferenceCategory
+        android:key="@string/pref_key_folder_sync_category"
+        android:title="@string/settings_folder_sync_title"
+        app:allowDividerAbove="false"
+        app:allowDividerBelow="false"
+        app:iconSpaceReserved="false">
+
+        <com.seafile.seadroid2.widget.prefs.TextTitleSummaryPreference
+            android:key="@string/pref_key_folder_sync_add"
+            android:title="@string/settings_folder_sync_add"
+            android:summary="@string/settings_folder_sync_add_summary"
+            app:backgroundColor="@color/pref_background_color"
+            app:iconSpaceReserved="false"
+            app:radiusPosition="top" />
+
+        <com.seafile.seadroid2.widget.prefs.TextTitleSummaryPreference
+            android:key="@string/pref_key_folder_sync_now"
+            android:title="@string/settings_folder_sync_now"
+            android:summary="@string/settings_folder_sync_now_summary"
+            app:backgroundColor="@color/pref_background_color"
+            app:iconSpaceReserved="false"
+            app:radiusPosition="bottom" />
+
+    </com.seafile.seadroid2.widget.prefs.CardPreferenceCategory>
+
+    <com.seafile.seadroid2.widget.prefs.CardPreferenceCategory
         android:title="@string/settings_storage_title"
         app:allowDividerAbove="false"
         app:allowDividerBelow="false"


### PR DESCRIPTION
## Summary

Adds a complete **bidirectional folder sync** feature that keeps a local SAF-backed directory in sync with a remote Seafile library folder. Users can configure multiple sync rules, each mapping a remote repo/path to a local directory, with granular control over which files are synced.

## Features

### Core Sync Engine
- **Bidirectional sync** — downloads new/modified remote files to local storage and uploads new/modified local files to the server
- **4-way sync state tracking** — compares remote state, local state, previous sync state snapshot, and current sync state to correctly detect additions, modifications, and deletions on both sides
- **Delete propagation** — files deleted on either side are propagated to the other side on the next sync cycle, with empty directories cleaned up automatically
- **Conflict-free operation** — uses 3-way merge logic in SyncStateManager to prevent race conditions between async transfer completions and state snapshots

### Sync Rules & Configuration
- **Multiple sync rules** — users can configure any number of independent sync rules, each with its own repo, remote path, and local directory
- **Rule management UI** — long-press on a sync rule in Settings to toggle, manage files, configure filters, or delete
- **Sync Now button** — manual on-demand sync trigger in addition to the 15-minute periodic schedule

### File Filtering & Exclusion
- **Per-file toggle** — dedicated activity (FolderSyncFilesActivity) shows all remote files with checkboxes to include/exclude individual files
- **Max file size filter** — skip files above a configurable size threshold (in MB)
- **Extension filter** — include-only or exclude specific file extensions (comma-separated)
- **Immediate effect** — unchecking a file immediately removes it from the download queue AND cancels any active in-progress download via OkHttp Call.cancel()
- **Local cleanup** — excluded files that were previously downloaded are removed from local storage

### Reliability
- **Foreground service** — FolderSyncWorker promotes to a foreground service with a persistent notification during active transfers, preventing the OS from killing the process
- **Concurrency guards** — initialDelay on periodic work and singleton execution prevent overlapping sync cycles and token-sharing 403 errors
- **Download retry** — leverages the existing ParentEventDownloader retry mechanism with primary/fallback HTTP clients
- **Thread-safe state management** — SyncStateManager and SyncExclusionManager use synchronized access with SharedPreferences-backed persistence

## Architecture

### New Files
| File | Purpose |
|------|---------|
| SyncRule.java | Data model for sync rules (repo, paths, filters) |
| SyncRuleManager.java | CRUD operations for sync rules in SharedPreferences |
| SyncStateManager.java | Tracks synced file paths per rule with 3-way merge |
| SyncExclusionManager.java | Per-file exclusion persistence per rule |
| FolderSyncWorker.java | WorkManager worker — sync orchestration with foreground service |
| FolderSyncUploader.java | Upload handler with sync state tracking on completion |
| FolderSyncNotificationHelper.java | Foreground service notification |
| FolderSyncFilesActivity.java | Per-file toggle UI |
| SyncFileAdapter.java | RecyclerView adapter with immediate queue/transfer cancellation |
| SyncFileItem.java | View model for file list items |
| ctivity_folder_sync_files.xml | Layout for file toggle activity |
| dialog_sync_filters.xml | Filter configuration dialog layout |
| item_sync_file.xml | List item layout with checkbox |

### Modified Files
| File | Change |
|------|--------|
| BackupThreadExecutor.java | Added folder sync uploader lifecycle management |
| ParentEventDownloader.java | Added moveToSyncDestination() for SAF-based file placement |
| BackgroundJobManagerImpl.java | Added scheduleFolderSync / unFolderSyncNow |
| DownloadWorker.java | Integrated folder sync download waiting |
| TransferQueue.java | Added emoveIf(Predicate) for targeted queue purging |
| FileService.java | Added listDirEntriesRecursive() and deleteFile() API endpoints |
| TabSettings2Fragment.java | Sync rule UI with 4-option management dialog and filter configuration |
| strings.xml | 15+ new string resources |
| AndroidManifest.xml | Registered FolderSyncFilesActivity |

## Testing

Tested manually against a Seafile 13 server with:
- Single and multiple sync rules
- Large file sets (100+ files)
- Bidirectional add/delete propagation
- File exclusion with active download cancellation
- Size and extension filtering
- App kill and restore (foreground service keeps transfers alive)
- Network interruption and retry