### PR TITLE
Fix unreadable markdown tables and code blocks in dark mode

### DIFF
--- a/app/src/main/java/com/seafile/seadroid2/ui/markdown/MarkdownActivity.java
+++ b/app/src/main/java/com/seafile/seadroid2/ui/markdown/MarkdownActivity.java
@@ -116,6 +116,10 @@ public class MarkdownActivity extends BaseActivityWithVM<EditorViewModel> implem
         if (mode == Configuration.UI_MODE_NIGHT_YES) {
             css.addRule("body", new String[]{"line-height: 1.6", "padding: 0px", "background-color: #222;"});
             css.addRule("body", "color: white");
+            css.addRule("table tr", "background-color: #222; color: white; border-top-color: #444");
+            css.addRule("table tr:nth-child(2n)", "background-color: #2c2c2c");
+            css.addRule("table th, table td", "border-color: #444");
+            css.addRule("code, pre", "background-color: #2c2c2c; color: white");
         } else {
             css.addRule("body", new String[]{"line-height: 1.6", "padding: 0px"});
         }


### PR DESCRIPTION
Closes #1142

## Problem

In dark mode, every second row of a Markdown table is white text on a near-white background and is unreadable. Code and pre blocks have the same problem to a lesser extent.

## Cause

`MarkdownActivity.initMarkdown()` only overrides the `body` color/background for `UI_MODE_NIGHT_YES`. The bundled `br.tiagohm.markdownview` GitHub stylesheet still applies a hardcoded `background-color: #f6f8fa` to `tr:nth-child(2n)`, and similar light backgrounds to `code`/`pre`.

## Fix

Inside the existing dark-mode branch, add CSS rules to override:

- `table tr` background and color
- `table tr:nth-child(2n)` background (the striping bug)
- `table th, table td` border color
- `code, pre` background and color

Four added lines, scoped entirely to the existing `UI_MODE_NIGHT_YES` block. No light-mode behavior changes.

## Test

Open any `.md` containing a table or code block in dark mode. Rows alternate between `#222` and `#2c2c2c`, all text remains white and legible.
