### PR TITLE
Bump bundled libheif to v1.22.2 (fix CVE-2026-32741 heap overflow in decode_mask_image)

### DIFF
--- a/build_libheif.sh
+++ b/build_libheif.sh
@@ -55,7 +55,7 @@ ABIS=(
 )
 
 # LibHeif version
-LIBHEIF_VERSION="v1.21.2"
+LIBHEIF_VERSION="v1.22.2"
 
 # LibJpeg version
 LIBJPEG_VERSION="3.1.3"


### PR DESCRIPTION
## Summary

Bumps the bundled **libheif** build pin in `build_libheif.sh` from `v1.21.2` to **`v1.22.2`** to address **CVE-2026-32741**.

`build_libheif.sh` is the source-build recipe for the prebuilt libraries committed under `app/src/main/cpp/libheif/lib/<abi>/libheif.so`. It clones `strukturag/libheif` at the tag in `LIBHEIF_VERSION` and produces the `.so` that ship in the APK. The pinned `v1.21.2` is affected by CVE-2026-32741.

## The vulnerability

CVE-2026-32741 is a heap-buffer-overflow **write** in `MaskImageCodec::decode_mask_image` (`libheif/image-items/mask_image.cc`). Through `v1.21.2` the size guard only checks a lower bound:

```cpp
if (data.size() < width * height) { ... }   // lower-bound only
...
memcpy(dst, data.data(), data.size());        // copies full item payload into a width*height plane
```

A crafted `mski` item whose payload is larger than the destination plane overflows the heap allocation. Fixed in **v1.22.0** via a division-based bound check and a `width*bytes_per_pixel*height`-bounded copy.

## Reachability in seadroid

The bundled libheif is reachable from the HEIC->JPEG conversion JNI path: `HeicNative.ConvertHeic2Jpeg` -> `ExtractPrimaryJpegFromHeic` -> `heif_context_read_from_file` -> `heif_decode_image` (`app/src/main/cpp/heicgen.cpp`). For a primary item of type `mski`, libheif dispatches to `decode_mask_image`. The file content is fully attacker-controlled (a downloaded/opened library file).

## Change

One-line bump: `LIBHEIF_VERSION="v1.21.2"` -> `LIBHEIF_VERSION="v1.22.2"`.

## Note for maintainers (action required)

This changes only the **build recipe**. The `.so` files committed under `app/src/main/cpp/libheif/lib/` are prebuilt artifacts and are **not** regenerated by this PR. To actually ship the fix, please re-run `build_libheif.sh` (macOS + Android NDK) after removing the existing `libheif.so` so the build is not skipped by the `check_needs` early-out, then commit the refreshed binaries. I cannot regenerate the cross-compiled Android `.so` in this PR.

Refs #1157

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)